### PR TITLE
[mpris] Properly clean up when playing client quits. Fixes JB#56799

### DIFF
--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -979,16 +979,19 @@ void MprisControllerPrivate::onServiceVanished(const QString &service)
     }
 
     m_availableClients.removeOne(client);
-    m_otherPlayingClients.removeOne(client);
-    Q_EMIT parent()->availableServicesChanged();
 
     if (m_currentClient == client) {
         if (m_singleService || m_availableClients.isEmpty()) {
             setCurrentClient(nullptr);
+        } else if (!m_otherPlayingClients.isEmpty()) {
+            setCurrentClient(m_otherPlayingClients[0]);
         } else {
             setCurrentClient(m_availableClients[0]);
         }
     }
+    m_otherPlayingClients.removeOne(client);
+
+    Q_EMIT parent()->availableServicesChanged();
 
     if (client) {
         client->deleteLater();


### PR DESCRIPTION
setCurrentClient puts current client to m_otherPlayingClients if
it is playing state, change the order of calls to ensure that the
gone client doesn't linger on.

Also prefer playing clients when choosing the new current client.