### PR TITLE
[amber-mpris] Remove the deprecated loop enums. JB#567401

### DIFF
--- a/src/mpris.h
+++ b/src/mpris.h
@@ -46,10 +46,7 @@ public:
     enum LoopStatus {
         LoopNone,
         LoopTrack,
-        LoopPlaylist,
-        None = LoopNone, // this and the following deprecated
-        Track = LoopTrack,
-        Playlist = LoopPlaylist
+        LoopPlaylist
     };
     Q_ENUM(LoopStatus);
 };


### PR DESCRIPTION
With module being new and used only in few places, there
should still be even a chance to get rid of the deprecated enum values.

@jpetrell @inzanity 