### PR TITLE
[mpris] Make it possible to configure build without QML. Fixes JB#57700

### DIFF
--- a/amber-mpris.pro
+++ b/amber-mpris.pro
@@ -1,4 +1,11 @@
 TEMPLATE = subdirs
-declarative.depends = src
 src.depends = qtdbusextended
-SUBDIRS = src declarative qtdbusextended doc
+SUBDIRS = src qtdbusextended doc
+
+no-qml {
+    message(Building without QML dependency.)
+} else {
+    message(Building with QML dependency.)
+    declarative.depends = src
+    SUBDIRS += declarative
+}


### PR DESCRIPTION
Configuring build with no-qml will drop qml dependency:

qmake CONFIG+=no-qml

In normal build qml dependency is used.

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>