### PR TITLE
Fix metaDataChanged propagation in MprisController

### DIFF
--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -695,7 +695,7 @@ void MprisClientPrivate::onMetadataChanged()
     if (oldTrackId != m_metaData.trackId()) {
         m_lastPosition = 0;
         m_positionElapsed.start();
-        Q_EMIT parent()->positionChanged(parent()->position());
+        Q_EMIT parent()->metaDataChanged();
     }
 }
 

--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -1124,7 +1124,6 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
     bool oldCanSeek = parent()->canSeek();
     Mpris::LoopStatus oldLoopStatus = parent()->loopStatus();
     double oldMaximumRate = parent()->maximumRate();
-    const MprisMetaData *oldMetaData = parent()->metaData();
     double oldMinimumRate = parent()->minimumRate();
     Mpris::PlaybackStatus oldPlaybackStatus = parent()->playbackStatus();
     double oldRate = parent()->rate();
@@ -1185,9 +1184,6 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
     if (oldMaximumRate != parent()->maximumRate()) {
         Q_EMIT parent()->maximumRateChanged();
     }
-    if (oldMetaData != parent()->metaData()) {
-        Q_EMIT parent()->metaDataChanged();
-    }
     if (oldMinimumRate != parent()->minimumRate()) {
         Q_EMIT parent()->minimumRateChanged();
     }
@@ -1234,6 +1230,8 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
         connect(m_currentClient, &MprisClient::shuffleChanged, parent(), &MprisController::shuffleChanged);
         connect(m_currentClient, &MprisClient::volumeChanged, parent(), &MprisController::volumeChanged);
         connect(m_currentClient, &MprisClient::seeked, parent(), &MprisController::seeked);
+
+        connect(m_currentClient, &MprisClient::metaDataChanged, parent(), &MprisController::metaDataChanged);
 
         if (m_currentClient->playbackStatus() == Mpris::Playing) {
             m_otherPlayingClients.removeOne(m_currentClient);


### PR DESCRIPTION
I wrote this QML code to bind to the `MprisController::metaDataChanged` signal, but it didn't print anything even if I was changing the song played by the Media player. 

```
MprisController {
        onMetaDataChanged: {
            console.log(metadata.title);
        }
}
```

Then I had a look to the code and found out there's no signal emitted in such case. Also, the `MprisClient` never emits `metaDataChanged` at all: it emits `positionChanged` instead, which looks wrong to me.

While I was on it, I also found out that `metaDataChanged` is emitted twice by the `MprisController` whenever the client changes: once if it differs from the old object and once before returning from the function. I removed the former.