### PR TITLE
mpris: Improve metadata extra field support.

### DIFF
--- a/src/mprismetadata.h
+++ b/src/mprismetadata.h
@@ -121,7 +121,9 @@ public:
     void setUseCount(const QVariant &count);
 
     QVariantMap extraFields() const;
+    QVariant extraField(const QString &key) const;
     void setExtraFields(const QVariantMap &fields);
+    void setExtraField(const QString &key, const QVariant &value);
 
     QVariant fillFrom() const;
     void setFillFrom(const QVariant &fillFrom);


### PR DESCRIPTION
[mpris] Improve metadata extra field support. JB#59021

The initial extraFields implementation omitted mpris: and xesam: ontologies though the latter is permissible and even recommended in the spec. Switch this to only ignore the fields that are used elsewhere.

Add extraField companion methods for settings individual fields for easier use.

Plus a small tweak to allow fields to be unset properly only when required. This was causing null values to be set repeatedly, and metadataChanged signals to be sent out too often.