### PR TITLE
Use correct multiplier for seek

### DIFF
--- a/declarative/declarativemprisplayer.cpp
+++ b/declarative/declarativemprisplayer.cpp
@@ -418,7 +418,8 @@ using namespace Amber;
     \qmlsignal MprisPlayer::seeked(int position)
 
     This signal should be emitted whenever there has been a non-linear change
-    in the position withing the currently playing media.
+    in the position within the currently playing media. The value is the new
+    position after seek in milliseconds.
 */
 
 /*!

--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -336,7 +336,7 @@ bool MprisClient::seek(qlonglong offset)
         return false;
     }
 
-    priv->handleCall(priv->m_mprisPlayerInterface.Seek(offset));
+    priv->handleCall(priv->m_mprisPlayerInterface.Seek(offset * 1000));
 
     return true;
 }


### PR DESCRIPTION
Use correct multiplier for seek. It was wrong on MprisClient side but correct on MprisPlayer.
https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek

Clarify position argument in MprisPlayer::seeked().
https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Signal:Seeked

Note how mpris specifies the values in microseconds but the library exposes them in milliseconds.