### PR TITLE
Refactor and fix metadata tracking api. JB#58070

### DIFF
--- a/declarative/declarativemprisplayer.cpp
+++ b/declarative/declarativemprisplayer.cpp
@@ -70,7 +70,7 @@ using namespace Amber;
     \qmlproperty bool MprisPlayer::canSetFullscreen
     \brief Sets indication whether the player can be told to go full screen
 
-    When set to true, a remote controlelr can emit the fullScreenRequested signal.
+    When set to true, a remote controller can emit the fullScreenRequested signal.
     Defaults to false.
 */
 

--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -643,7 +643,7 @@ void MprisClientPrivate::onAsyncGetAllRootPropertiesFinished()
     m_initedRootInterface = true;
 
     if (parent()->isValid()) {
-            Q_EMIT parent()->isValidChanged();
+        Q_EMIT parent()->isValidChanged();
     }
 }
 
@@ -659,7 +659,7 @@ void MprisClientPrivate::onAsyncGetAllPlayerPropertiesFinished()
     m_initedPlayerInterface = true;
 
     if (parent()->isValid()) {
-            Q_EMIT parent()->isValidChanged();
+        Q_EMIT parent()->isValidChanged();
     }
 }
 

--- a/src/mprisclient.h
+++ b/src/mprisclient.h
@@ -101,44 +101,29 @@ public:
 
     // Mpris2 Root Interface
     bool canQuit() const;
-
     bool canRaise() const;
-
     bool canSetFullscreen() const;
-
     QString desktopEntry() const;
-
     bool fullscreen() const;
     void setFullscreen(bool fullscreen);
-
     bool hasTrackList() const;
-
     QString identity() const;
-
     QStringList supportedUriSchemes() const;
-
     QStringList supportedMimeTypes() const;
 
     // Mpris2 Player Interface
     bool canControl() const;
-
     bool canGoNext() const;
-
     bool canGoPrevious() const;
-
     bool canPause() const;
-
     bool canPlay() const;
-
     bool canSeek() const;
 
     Mpris::LoopStatus loopStatus() const;
     void setLoopStatus(Mpris::LoopStatus loopStatus);
 
     double maximumRate() const;
-
     MprisMetaData *metaData() const;
-
     double minimumRate() const;
 
     Mpris::PlaybackStatus playbackStatus() const;

--- a/src/mprisclient.h
+++ b/src/mprisclient.h
@@ -64,7 +64,7 @@ class AMBER_MPRIS_EXPORT MprisClient : public QObject
     Q_PROPERTY(bool canSeek READ canSeek NOTIFY canSeekChanged)
     Q_PROPERTY(Amber::Mpris::LoopStatus loopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
     Q_PROPERTY(double maximumRate READ maximumRate NOTIFY maximumRateChanged)
-    Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData NOTIFY metaDataChanged)
+    Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData CONSTANT)
     Q_PROPERTY(double minimumRate READ minimumRate NOTIFY minimumRateChanged)
     Q_PROPERTY(Amber::Mpris::PlaybackStatus playbackStatus READ playbackStatus NOTIFY playbackStatusChanged)
     Q_PROPERTY(qlonglong position READ position NOTIFY positionChanged)
@@ -164,7 +164,6 @@ Q_SIGNALS:
     void canSeekChanged();
     void loopStatusChanged();
     void maximumRateChanged();
-    void metaDataChanged();
     void minimumRateChanged();
     void playbackStatusChanged();
     void positionChanged(qlonglong position);

--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -476,9 +476,6 @@ public:
     MprisControllerPrivate(MprisController *parent);
     ~MprisControllerPrivate();
 
-    MprisController *parent() const;
-
-
 public Q_SLOTS:
     void onNameOwnerChanged(const QString &service, const QString &oldOwner, const QString& newOwner);
     void onServiceAppeared(const QString &service);
@@ -491,6 +488,7 @@ public:
     void setCurrentClient(MprisClient *client);
     bool checkClient(const char *callerName) const;
 
+    MprisController *q_ptr;
     bool m_singleService;
     QString m_singleServiceName;
     MprisClient *m_currentClient;
@@ -505,6 +503,7 @@ public:
 
 MprisControllerPrivate::MprisControllerPrivate(MprisController *parent)
     : QObject(parent)
+    , q_ptr(parent)
     , m_singleService(false)
     , m_currentClient(nullptr)
     , m_connection(getDBusConnection())
@@ -534,11 +533,6 @@ MprisControllerPrivate::MprisControllerPrivate(MprisController *parent)
 
 MprisControllerPrivate::~MprisControllerPrivate()
 {
-}
-
-MprisController *MprisControllerPrivate::parent() const
-{
-    return static_cast<MprisController *>(QObject::parent());
 }
 
 MprisController::MprisController(QObject *parent)
@@ -916,7 +910,7 @@ void MprisControllerPrivate::onServiceAppeared(const QString &service)
             }
         }
 
-        Q_EMIT parent()->availableServicesChanged();
+        Q_EMIT q_ptr->availableServicesChanged();
         client->deleteLater();
     } else {
         client = pendingClient(service);
@@ -931,7 +925,7 @@ void MprisControllerPrivate::onServiceAppeared(const QString &service)
 
     auto validHandler = [this, client] {
         bool emitted = false;
-        QMetaObject::Connection connection = connect(parent(), &MprisController::availableServicesChanged, this, [&emitted] { emitted = true; }, Qt::DirectConnection);
+        QMetaObject::Connection connection = connect(q_ptr, &MprisController::availableServicesChanged, this, [&emitted] { emitted = true; }, Qt::DirectConnection);
         m_pendingClients.removeOne(client);
         m_availableClients.prepend(client);
         if ((m_singleService && client->service() == m_singleServiceName)
@@ -944,9 +938,9 @@ void MprisControllerPrivate::onServiceAppeared(const QString &service)
         onAvailableClientPlaybackStatusChanged(client);
 
         if (!emitted) {
-            Q_EMIT parent()->availableServicesChanged();
+            Q_EMIT q_ptr->availableServicesChanged();
         }
-        parent()->disconnect(connection);
+        q_ptr->disconnect(connection);
     };
 
     if (!client->isValid()) {
@@ -994,7 +988,7 @@ void MprisControllerPrivate::onServiceVanished(const QString &service)
     }
     m_otherPlayingClients.removeOne(client);
 
-    Q_EMIT parent()->availableServicesChanged();
+    Q_EMIT q_ptr->availableServicesChanged();
 
     if (client) {
         client->deleteLater();
@@ -1007,7 +1001,7 @@ void MprisControllerPrivate::onAvailableClientPlaybackStatusChanged(MprisClient 
         if (m_currentClient->playbackStatus() == Mpris::Playing) {
             if (m_availableClients[0] != m_currentClient) {
                 m_availableClients.move(m_availableClients.indexOf(m_currentClient), 0);
-                Q_EMIT parent()->availableServicesChanged();
+                Q_EMIT q_ptr->availableServicesChanged();
             }
             return;
         }
@@ -1016,7 +1010,7 @@ void MprisControllerPrivate::onAvailableClientPlaybackStatusChanged(MprisClient 
             m_availableClients.move(m_availableClients.indexOf(m_currentClient), m_otherPlayingClients.length());
             MprisClient *currentClient = m_otherPlayingClients.takeFirst();
             m_availableClients.move(m_availableClients.indexOf(currentClient), 0);
-            Q_EMIT parent()->availableServicesChanged();
+            Q_EMIT q_ptr->availableServicesChanged();
 
             if (!m_singleService) {
                 setCurrentClient(currentClient);
@@ -1026,13 +1020,13 @@ void MprisControllerPrivate::onAvailableClientPlaybackStatusChanged(MprisClient 
         if (client->playbackStatus() != Mpris::Playing) {
             if (m_otherPlayingClients.removeOne(client)) {
                 m_availableClients.move(m_availableClients.indexOf(client), m_otherPlayingClients.length());
-                Q_EMIT parent()->availableServicesChanged();
+                Q_EMIT q_ptr->availableServicesChanged();
             }
             return;
         }
 
         m_availableClients.move(m_availableClients.indexOf(client), 0);
-        Q_EMIT parent()->availableServicesChanged();
+        Q_EMIT q_ptr->availableServicesChanged();
 
         if (!m_singleService && (!m_currentClient
             || m_currentClient->playbackStatus() != Mpris::Playing)) {
@@ -1078,174 +1072,174 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
 
     if (m_currentClient) {
         // Mpris Root Interface
-        disconnect(m_currentClient, &MprisClient::canQuitChanged, parent(), &MprisController::canQuitChanged);
-        disconnect(m_currentClient, &MprisClient::canRaiseChanged, parent(), &MprisController::canRaiseChanged);
-        disconnect(m_currentClient, &MprisClient::canSetFullscreenChanged, parent(), &MprisController::canSetFullscreenChanged);
-        disconnect(m_currentClient, &MprisClient::desktopEntryChanged, parent(), &MprisController::desktopEntryChanged);
-        disconnect(m_currentClient, &MprisClient::fullscreenChanged, parent(), &MprisController::fullscreenChanged);
-        disconnect(m_currentClient, &MprisClient::hasTrackListChanged, parent(), &MprisController::hasTrackListChanged);
-        disconnect(m_currentClient, &MprisClient::identityChanged, parent(), &MprisController::identityChanged);
-        disconnect(m_currentClient, &MprisClient::supportedUriSchemesChanged, parent(), &MprisController::supportedUriSchemesChanged);
-        disconnect(m_currentClient, &MprisClient::supportedMimeTypesChanged, parent(), &MprisController::supportedMimeTypesChanged);
+        disconnect(m_currentClient, &MprisClient::canQuitChanged, q_ptr, &MprisController::canQuitChanged);
+        disconnect(m_currentClient, &MprisClient::canRaiseChanged, q_ptr, &MprisController::canRaiseChanged);
+        disconnect(m_currentClient, &MprisClient::canSetFullscreenChanged, q_ptr, &MprisController::canSetFullscreenChanged);
+        disconnect(m_currentClient, &MprisClient::desktopEntryChanged, q_ptr, &MprisController::desktopEntryChanged);
+        disconnect(m_currentClient, &MprisClient::fullscreenChanged, q_ptr, &MprisController::fullscreenChanged);
+        disconnect(m_currentClient, &MprisClient::hasTrackListChanged, q_ptr, &MprisController::hasTrackListChanged);
+        disconnect(m_currentClient, &MprisClient::identityChanged, q_ptr, &MprisController::identityChanged);
+        disconnect(m_currentClient, &MprisClient::supportedUriSchemesChanged, q_ptr, &MprisController::supportedUriSchemesChanged);
+        disconnect(m_currentClient, &MprisClient::supportedMimeTypesChanged, q_ptr, &MprisController::supportedMimeTypesChanged);
 
         // Mpris Player Interface
-        disconnect(m_currentClient, &MprisClient::canControlChanged, parent(), &MprisController::canControlChanged);
-        disconnect(m_currentClient, &MprisClient::canGoNextChanged, parent(), &MprisController::canGoNextChanged);
-        disconnect(m_currentClient, &MprisClient::canGoPreviousChanged, parent(), &MprisController::canGoPreviousChanged);
-        disconnect(m_currentClient, &MprisClient::canPauseChanged, parent(), &MprisController::canPauseChanged);
-        disconnect(m_currentClient, &MprisClient::canPlayChanged, parent(), &MprisController::canPlayChanged);
-        disconnect(m_currentClient, &MprisClient::canSeekChanged, parent(), &MprisController::canSeekChanged);
-        disconnect(m_currentClient, &MprisClient::loopStatusChanged, parent(), &MprisController::loopStatusChanged);
-        disconnect(m_currentClient, &MprisClient::maximumRateChanged, parent(), &MprisController::maximumRateChanged);
-        disconnect(m_currentClient, &MprisClient::minimumRateChanged, parent(), &MprisController::minimumRateChanged);
-        disconnect(m_currentClient, &MprisClient::playbackStatusChanged, parent(), &MprisController::playbackStatusChanged);
-        disconnect(m_currentClient, &MprisClient::positionChanged, parent(), &MprisController::positionChanged);
-        disconnect(m_currentClient, &MprisClient::rateChanged, parent(), &MprisController::rateChanged);
-        disconnect(m_currentClient, &MprisClient::shuffleChanged, parent(), &MprisController::shuffleChanged);
-        disconnect(m_currentClient, &MprisClient::volumeChanged, parent(), &MprisController::volumeChanged);
-        disconnect(m_currentClient, &MprisClient::seeked, parent(), &MprisController::seeked);
+        disconnect(m_currentClient, &MprisClient::canControlChanged, q_ptr, &MprisController::canControlChanged);
+        disconnect(m_currentClient, &MprisClient::canGoNextChanged, q_ptr, &MprisController::canGoNextChanged);
+        disconnect(m_currentClient, &MprisClient::canGoPreviousChanged, q_ptr, &MprisController::canGoPreviousChanged);
+        disconnect(m_currentClient, &MprisClient::canPauseChanged, q_ptr, &MprisController::canPauseChanged);
+        disconnect(m_currentClient, &MprisClient::canPlayChanged, q_ptr, &MprisController::canPlayChanged);
+        disconnect(m_currentClient, &MprisClient::canSeekChanged, q_ptr, &MprisController::canSeekChanged);
+        disconnect(m_currentClient, &MprisClient::loopStatusChanged, q_ptr, &MprisController::loopStatusChanged);
+        disconnect(m_currentClient, &MprisClient::maximumRateChanged, q_ptr, &MprisController::maximumRateChanged);
+        disconnect(m_currentClient, &MprisClient::minimumRateChanged, q_ptr, &MprisController::minimumRateChanged);
+        disconnect(m_currentClient, &MprisClient::playbackStatusChanged, q_ptr, &MprisController::playbackStatusChanged);
+        disconnect(m_currentClient, &MprisClient::positionChanged, q_ptr, &MprisController::positionChanged);
+        disconnect(m_currentClient, &MprisClient::rateChanged, q_ptr, &MprisController::rateChanged);
+        disconnect(m_currentClient, &MprisClient::shuffleChanged, q_ptr, &MprisController::shuffleChanged);
+        disconnect(m_currentClient, &MprisClient::volumeChanged, q_ptr, &MprisController::volumeChanged);
+        disconnect(m_currentClient, &MprisClient::seeked, q_ptr, &MprisController::seeked);
 
         if (m_currentClient->playbackStatus() == Mpris::Playing) {
             m_otherPlayingClients.prepend(m_currentClient);
         }
     }
 
-    bool oldCanQuit = parent()->canQuit();
-    bool oldCanRaise = parent()->canRaise();
-    bool oldCanSetFullscreen = parent()->canSetFullscreen();
-    QString oldDesktopEntry = parent()->desktopEntry();
-    bool oldFullscreen = parent()->fullscreen();
-    bool oldHasTrackList = parent()->hasTrackList();
-    QString oldIdentity = parent()->identity();
-    QStringList oldSupportedUriSchemes = parent()->supportedUriSchemes();
-    QStringList oldSupportedMimeTypes = parent()->supportedMimeTypes();
-    bool oldCanControl = parent()->canControl();
-    bool oldCanGoNext = parent()->canGoNext();
-    bool oldCanGoPrevious = parent()->canGoPrevious();
-    bool oldCanPause = parent()->canPause();
-    bool oldCanPlay = parent()->canPlay();
-    bool oldCanSeek = parent()->canSeek();
-    Mpris::LoopStatus oldLoopStatus = parent()->loopStatus();
-    double oldMaximumRate = parent()->maximumRate();
-    const MprisMetaData *oldMetaData = parent()->metaData();
-    double oldMinimumRate = parent()->minimumRate();
-    Mpris::PlaybackStatus oldPlaybackStatus = parent()->playbackStatus();
-    double oldRate = parent()->rate();
-    bool oldShuffle = parent()->shuffle();
-    double oldVolume = parent()->volume();
+    bool oldCanQuit = q_ptr->canQuit();
+    bool oldCanRaise = q_ptr->canRaise();
+    bool oldCanSetFullscreen = q_ptr->canSetFullscreen();
+    QString oldDesktopEntry = q_ptr->desktopEntry();
+    bool oldFullscreen = q_ptr->fullscreen();
+    bool oldHasTrackList = q_ptr->hasTrackList();
+    QString oldIdentity = q_ptr->identity();
+    QStringList oldSupportedUriSchemes = q_ptr->supportedUriSchemes();
+    QStringList oldSupportedMimeTypes = q_ptr->supportedMimeTypes();
+    bool oldCanControl = q_ptr->canControl();
+    bool oldCanGoNext = q_ptr->canGoNext();
+    bool oldCanGoPrevious = q_ptr->canGoPrevious();
+    bool oldCanPause = q_ptr->canPause();
+    bool oldCanPlay = q_ptr->canPlay();
+    bool oldCanSeek = q_ptr->canSeek();
+    Mpris::LoopStatus oldLoopStatus = q_ptr->loopStatus();
+    double oldMaximumRate = q_ptr->maximumRate();
+    const MprisMetaData *oldMetaData = q_ptr->metaData();
+    double oldMinimumRate = q_ptr->minimumRate();
+    Mpris::PlaybackStatus oldPlaybackStatus = q_ptr->playbackStatus();
+    double oldRate = q_ptr->rate();
+    bool oldShuffle = q_ptr->shuffle();
+    double oldVolume = q_ptr->volume();
 
     m_currentClient = client;
 
-    if (oldCanQuit != parent()->canQuit()) {
-        Q_EMIT parent()->canQuitChanged();
+    if (oldCanQuit != q_ptr->canQuit()) {
+        Q_EMIT q_ptr->canQuitChanged();
     }
-    if (oldCanRaise != parent()->canRaise()) {
-        Q_EMIT parent()->canRaiseChanged();
+    if (oldCanRaise != q_ptr->canRaise()) {
+        Q_EMIT q_ptr->canRaiseChanged();
     }
-    if (oldCanSetFullscreen != parent()->canSetFullscreen()) {
-        Q_EMIT parent()->canSetFullscreenChanged();
+    if (oldCanSetFullscreen != q_ptr->canSetFullscreen()) {
+        Q_EMIT q_ptr->canSetFullscreenChanged();
     }
-    if (oldDesktopEntry != parent()->desktopEntry()) {
-        Q_EMIT parent()->desktopEntryChanged();
+    if (oldDesktopEntry != q_ptr->desktopEntry()) {
+        Q_EMIT q_ptr->desktopEntryChanged();
     }
-    if (oldFullscreen != parent()->fullscreen()) {
-        Q_EMIT parent()->fullscreenChanged();
+    if (oldFullscreen != q_ptr->fullscreen()) {
+        Q_EMIT q_ptr->fullscreenChanged();
     }
-    if (oldHasTrackList != parent()->hasTrackList()) {
-        Q_EMIT parent()->hasTrackListChanged();
+    if (oldHasTrackList != q_ptr->hasTrackList()) {
+        Q_EMIT q_ptr->hasTrackListChanged();
     }
-    if (oldIdentity != parent()->identity()) {
-        Q_EMIT parent()->identityChanged();
+    if (oldIdentity != q_ptr->identity()) {
+        Q_EMIT q_ptr->identityChanged();
     }
-    if (oldSupportedUriSchemes != parent()->supportedUriSchemes()) {
-        Q_EMIT parent()->supportedUriSchemesChanged();
+    if (oldSupportedUriSchemes != q_ptr->supportedUriSchemes()) {
+        Q_EMIT q_ptr->supportedUriSchemesChanged();
     }
-    if (oldSupportedMimeTypes != parent()->supportedMimeTypes()) {
-        Q_EMIT parent()->supportedMimeTypesChanged();
+    if (oldSupportedMimeTypes != q_ptr->supportedMimeTypes()) {
+        Q_EMIT q_ptr->supportedMimeTypesChanged();
     }
 
-    if (oldCanControl != parent()->canControl()) {
-        Q_EMIT parent()->canControlChanged();
+    if (oldCanControl != q_ptr->canControl()) {
+        Q_EMIT q_ptr->canControlChanged();
     }
-    if (oldCanGoNext != parent()->canGoNext()) {
-        Q_EMIT parent()->canGoNextChanged();
+    if (oldCanGoNext != q_ptr->canGoNext()) {
+        Q_EMIT q_ptr->canGoNextChanged();
     }
-    if (oldCanGoPrevious != parent()->canGoPrevious()) {
-        Q_EMIT parent()->canGoPreviousChanged();
+    if (oldCanGoPrevious != q_ptr->canGoPrevious()) {
+        Q_EMIT q_ptr->canGoPreviousChanged();
     }
-    if (oldCanPause != parent()->canPause()) {
-        Q_EMIT parent()->canPauseChanged();
+    if (oldCanPause != q_ptr->canPause()) {
+        Q_EMIT q_ptr->canPauseChanged();
     }
-    if (oldCanPlay != parent()->canPlay()) {
-        Q_EMIT parent()->canPlayChanged();
+    if (oldCanPlay != q_ptr->canPlay()) {
+        Q_EMIT q_ptr->canPlayChanged();
     }
-    if (oldCanSeek != parent()->canSeek()) {
-        Q_EMIT parent()->canSeekChanged();
+    if (oldCanSeek != q_ptr->canSeek()) {
+        Q_EMIT q_ptr->canSeekChanged();
     }
-    if (oldLoopStatus != parent()->loopStatus()) {
-        Q_EMIT parent()->loopStatusChanged();
+    if (oldLoopStatus != q_ptr->loopStatus()) {
+        Q_EMIT q_ptr->loopStatusChanged();
     }
-    if (oldMaximumRate != parent()->maximumRate()) {
-        Q_EMIT parent()->maximumRateChanged();
+    if (oldMaximumRate != q_ptr->maximumRate()) {
+        Q_EMIT q_ptr->maximumRateChanged();
     }
-    if (oldMetaData != parent()->metaData()) {
-        Q_EMIT parent()->metaDataChanged();
+    if (oldMetaData != q_ptr->metaData()) {
+        Q_EMIT q_ptr->metaDataChanged();
     }
-    if (oldMinimumRate != parent()->minimumRate()) {
-        Q_EMIT parent()->minimumRateChanged();
+    if (oldMinimumRate != q_ptr->minimumRate()) {
+        Q_EMIT q_ptr->minimumRateChanged();
     }
-    if (oldPlaybackStatus != parent()->playbackStatus()) {
-        Q_EMIT parent()->playbackStatusChanged();
+    if (oldPlaybackStatus != q_ptr->playbackStatus()) {
+        Q_EMIT q_ptr->playbackStatusChanged();
     }
-    if (oldRate != parent()->rate()) {
-        Q_EMIT parent()->rateChanged();
+    if (oldRate != q_ptr->rate()) {
+        Q_EMIT q_ptr->rateChanged();
     }
-    if (oldShuffle != parent()->shuffle()) {
-        Q_EMIT parent()->shuffleChanged();
+    if (oldShuffle != q_ptr->shuffle()) {
+        Q_EMIT q_ptr->shuffleChanged();
     }
-    if (oldVolume != parent()->volume()) {
-        Q_EMIT parent()->volumeChanged();
+    if (oldVolume != q_ptr->volume()) {
+        Q_EMIT q_ptr->volumeChanged();
     }
 
     if (m_currentClient) {
         // Mpris Root Interface
-        connect(m_currentClient, &MprisClient::canQuitChanged, parent(), &MprisController::canQuitChanged);
-        connect(m_currentClient, &MprisClient::canRaiseChanged, parent(), &MprisController::canRaiseChanged);
-        connect(m_currentClient, &MprisClient::canSetFullscreenChanged, parent(), &MprisController::canSetFullscreenChanged);
-        connect(m_currentClient, &MprisClient::desktopEntryChanged, parent(), &MprisController::desktopEntryChanged);
-        connect(m_currentClient, &MprisClient::fullscreenChanged, parent(), &MprisController::fullscreenChanged);
-        connect(m_currentClient, &MprisClient::hasTrackListChanged, parent(), &MprisController::hasTrackListChanged);
-        connect(m_currentClient, &MprisClient::identityChanged, parent(), &MprisController::identityChanged);
-        connect(m_currentClient, &MprisClient::supportedUriSchemesChanged, parent(), &MprisController::supportedUriSchemesChanged);
-        connect(m_currentClient, &MprisClient::supportedMimeTypesChanged, parent(), &MprisController::supportedMimeTypesChanged);
-        connect(m_currentClient, &MprisClient::canControlChanged, parent(), &MprisController::canControlChanged);
+        connect(m_currentClient, &MprisClient::canQuitChanged, q_ptr, &MprisController::canQuitChanged);
+        connect(m_currentClient, &MprisClient::canRaiseChanged, q_ptr, &MprisController::canRaiseChanged);
+        connect(m_currentClient, &MprisClient::canSetFullscreenChanged, q_ptr, &MprisController::canSetFullscreenChanged);
+        connect(m_currentClient, &MprisClient::desktopEntryChanged, q_ptr, &MprisController::desktopEntryChanged);
+        connect(m_currentClient, &MprisClient::fullscreenChanged, q_ptr, &MprisController::fullscreenChanged);
+        connect(m_currentClient, &MprisClient::hasTrackListChanged, q_ptr, &MprisController::hasTrackListChanged);
+        connect(m_currentClient, &MprisClient::identityChanged, q_ptr, &MprisController::identityChanged);
+        connect(m_currentClient, &MprisClient::supportedUriSchemesChanged, q_ptr, &MprisController::supportedUriSchemesChanged);
+        connect(m_currentClient, &MprisClient::supportedMimeTypesChanged, q_ptr, &MprisController::supportedMimeTypesChanged);
+        connect(m_currentClient, &MprisClient::canControlChanged, q_ptr, &MprisController::canControlChanged);
 
         // Mpris Player Interface
-        connect(m_currentClient, &MprisClient::canGoNextChanged, parent(), &MprisController::canGoNextChanged);
-        connect(m_currentClient, &MprisClient::canGoPreviousChanged, parent(), &MprisController::canGoPreviousChanged);
-        connect(m_currentClient, &MprisClient::canPauseChanged, parent(), &MprisController::canPauseChanged);
-        connect(m_currentClient, &MprisClient::canPlayChanged, parent(), &MprisController::canPlayChanged);
-        connect(m_currentClient, &MprisClient::canSeekChanged, parent(), &MprisController::canSeekChanged);
-        connect(m_currentClient, &MprisClient::loopStatusChanged, parent(), &MprisController::loopStatusChanged);
-        connect(m_currentClient, &MprisClient::maximumRateChanged, parent(), &MprisController::maximumRateChanged);
-        connect(m_currentClient, &MprisClient::minimumRateChanged, parent(), &MprisController::minimumRateChanged);
-        connect(m_currentClient, &MprisClient::playbackStatusChanged, parent(), &MprisController::playbackStatusChanged);
+        connect(m_currentClient, &MprisClient::canGoNextChanged, q_ptr, &MprisController::canGoNextChanged);
+        connect(m_currentClient, &MprisClient::canGoPreviousChanged, q_ptr, &MprisController::canGoPreviousChanged);
+        connect(m_currentClient, &MprisClient::canPauseChanged, q_ptr, &MprisController::canPauseChanged);
+        connect(m_currentClient, &MprisClient::canPlayChanged, q_ptr, &MprisController::canPlayChanged);
+        connect(m_currentClient, &MprisClient::canSeekChanged, q_ptr, &MprisController::canSeekChanged);
+        connect(m_currentClient, &MprisClient::loopStatusChanged, q_ptr, &MprisController::loopStatusChanged);
+        connect(m_currentClient, &MprisClient::maximumRateChanged, q_ptr, &MprisController::maximumRateChanged);
+        connect(m_currentClient, &MprisClient::minimumRateChanged, q_ptr, &MprisController::minimumRateChanged);
+        connect(m_currentClient, &MprisClient::playbackStatusChanged, q_ptr, &MprisController::playbackStatusChanged);
         if (m_positionConnected) {
-            connect(m_currentClient, &MprisClient::positionChanged, parent(), &MprisController::positionChanged);
+            connect(m_currentClient, &MprisClient::positionChanged, q_ptr, &MprisController::positionChanged);
         }
-        connect(m_currentClient, &MprisClient::rateChanged, parent(), &MprisController::rateChanged);
-        connect(m_currentClient, &MprisClient::shuffleChanged, parent(), &MprisController::shuffleChanged);
-        connect(m_currentClient, &MprisClient::volumeChanged, parent(), &MprisController::volumeChanged);
-        connect(m_currentClient, &MprisClient::seeked, parent(), &MprisController::seeked);
+        connect(m_currentClient, &MprisClient::rateChanged, q_ptr, &MprisController::rateChanged);
+        connect(m_currentClient, &MprisClient::shuffleChanged, q_ptr, &MprisController::shuffleChanged);
+        connect(m_currentClient, &MprisClient::volumeChanged, q_ptr, &MprisController::volumeChanged);
+        connect(m_currentClient, &MprisClient::seeked, q_ptr, &MprisController::seeked);
 
         if (m_currentClient->playbackStatus() == Mpris::Playing) {
             m_otherPlayingClients.removeOne(m_currentClient);
         }
     }
 
-    Q_EMIT parent()->currentServiceChanged();
-    Q_EMIT parent()->metaDataChanged();
-    Q_EMIT parent()->positionChanged(parent()->position());
+    Q_EMIT q_ptr->currentServiceChanged();
+    Q_EMIT q_ptr->metaDataChanged();
+    Q_EMIT q_ptr->positionChanged(q_ptr->position());
 }
 
 bool MprisControllerPrivate::checkClient(const char *callerName) const

--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -497,7 +497,7 @@ public:
     QList<MprisClient *> m_pendingClients;
     QList<MprisClient *> m_availableClients;
     QList<MprisClient *> m_otherPlayingClients;
-    unsigned m_positionConnected;
+    unsigned m_positionConnectionCount;
 };
 }
 
@@ -508,7 +508,7 @@ MprisControllerPrivate::MprisControllerPrivate(MprisController *parent)
     , m_currentClient(nullptr)
     , m_connection(getDBusConnection())
     , m_dummyMetaData(this)
-    , m_positionConnected(0)
+    , m_positionConnectionCount(0)
 {
     if (!m_connection.isConnected()) {
         qCWarning(lcController) << "Mpris: Failed attempting to connect to DBus";
@@ -852,7 +852,7 @@ void MprisController::setVolume(double volume)
 void MprisController::connectNotify(const QMetaMethod &method)
 {
     if (method == QMetaMethod::fromSignal(&MprisController::positionChanged)) {
-        if (!priv->m_positionConnected++ && priv->m_currentClient) {
+        if (!priv->m_positionConnectionCount++ && priv->m_currentClient) {
             connect(priv->m_currentClient, &MprisClient::positionChanged, this, &MprisController::positionChanged);
         }
     }
@@ -861,7 +861,7 @@ void MprisController::connectNotify(const QMetaMethod &method)
 void MprisController::disconnectNotify(const QMetaMethod &method)
 {
     if (method == QMetaMethod::fromSignal(&MprisController::positionChanged)) {
-        if (!--priv->m_positionConnected && priv->m_currentClient) {
+        if (!--priv->m_positionConnectionCount && priv->m_currentClient) {
             disconnect(priv->m_currentClient, &MprisClient::positionChanged, this, &MprisController::positionChanged);
         }
     }
@@ -1224,7 +1224,7 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
         connect(m_currentClient, &MprisClient::maximumRateChanged, q_ptr, &MprisController::maximumRateChanged);
         connect(m_currentClient, &MprisClient::minimumRateChanged, q_ptr, &MprisController::minimumRateChanged);
         connect(m_currentClient, &MprisClient::playbackStatusChanged, q_ptr, &MprisController::playbackStatusChanged);
-        if (m_positionConnected) {
+        if (m_positionConnectionCount) {
             connect(m_currentClient, &MprisClient::positionChanged, q_ptr, &MprisController::positionChanged);
         }
         connect(m_currentClient, &MprisClient::rateChanged, q_ptr, &MprisController::rateChanged);

--- a/src/mpriscontroller.h
+++ b/src/mpriscontroller.h
@@ -69,7 +69,7 @@ class AMBER_MPRIS_EXPORT MprisController : public QObject
     Q_PROPERTY(bool canSeek READ canSeek NOTIFY canSeekChanged)
     Q_PROPERTY(Amber::Mpris::LoopStatus loopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
     Q_PROPERTY(double maximumRate READ maximumRate NOTIFY maximumRateChanged)
-    Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData NOTIFY metaDataChanged)
+    Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData CONSTANT)
     Q_PROPERTY(double minimumRate READ minimumRate NOTIFY minimumRateChanged)
     Q_PROPERTY(Amber::Mpris::PlaybackStatus playbackStatus READ playbackStatus NOTIFY playbackStatusChanged)
     Q_PROPERTY(qlonglong position READ position NOTIFY positionChanged)
@@ -174,7 +174,6 @@ Q_SIGNALS:
     void canSeekChanged();
     void loopStatusChanged();
     void maximumRateChanged();
-    void metaDataChanged();
     void minimumRateChanged();
     void playbackStatusChanged();
     void positionChanged(qlonglong position);

--- a/src/mpriscontroller.h
+++ b/src/mpriscontroller.h
@@ -78,7 +78,6 @@ class AMBER_MPRIS_EXPORT MprisController : public QObject
     Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
 
 public:
-
     MprisController(QObject *parent = 0);
     ~MprisController();
 
@@ -109,44 +108,31 @@ public:
 
     // Mpris2 Root Interface
     bool canQuit() const;
-
     bool canRaise() const;
-
     bool canSetFullscreen() const;
-
     QString desktopEntry() const;
 
     bool fullscreen() const;
     void setFullscreen(bool fullscreen);
 
     bool hasTrackList() const;
-
     QString identity() const;
-
     QStringList supportedUriSchemes() const;
-
     QStringList supportedMimeTypes() const;
 
     // Mpris2 Player Interface
     bool canControl() const;
-
     bool canGoNext() const;
-
     bool canGoPrevious() const;
-
     bool canPause() const;
-
     bool canPlay() const;
-
     bool canSeek() const;
 
     Mpris::LoopStatus loopStatus() const;
     void setLoopStatus(Mpris::LoopStatus loopStatus);
 
     double maximumRate() const;
-
     MprisMetaData *metaData() const;
-
     double minimumRate() const;
 
     Mpris::PlaybackStatus playbackStatus() const;

--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -716,15 +716,13 @@ void MprisMetaData::setFillFrom(const QVariant &fillFrom)
 
         for (int i = thisMeta->propertyOffset(); i < thisMeta->propertyCount(); i++) {
             QMetaProperty thisProp = thisMeta->property(i);
-            int j;
-
             if (QLatin1String("fillFrom") == thisProp.name())
                 continue;
 
-            j = thatMeta->indexOfProperty(thisProp.name());
+            int propertyIndex = thatMeta->indexOfProperty(thisProp.name());
 
-            if (j >= 0) {
-                QMetaProperty thatProp = thatMeta->property(j);
+            if (propertyIndex >= 0) {
+                QMetaProperty thatProp = thatMeta->property(propertyIndex);
                 if (thatProp.hasNotifySignal()) {
                     connect(&*priv->m_fillFromObject, thatProp.notifySignal(),
                             priv, fillFromChanged);

--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -400,12 +400,12 @@ QVariantMap MprisMetaDataPrivate::typedMetaData() const
 void MprisMetaDataPrivate::setMetaData(const QString &key, const QVariant &value)
 {
     if (!value.isValid() || value.isNull()) {
-            if (!m_metaData.remove(key))
-                    return;
-    } else if (m_metaData.value(key) != value) {
-            m_metaData[key] = value;
-    } else {
+        if (!m_metaData.remove(key))
             return;
+    } else if (m_metaData.value(key) != value) {
+        m_metaData[key] = value;
+    } else {
+        return;
     }
     m_changedDelay.start();
 }

--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -420,6 +420,10 @@ MprisMetaData::MprisMetaData(QObject *parent)
 {
 }
 
+MprisMetaData::~MprisMetaData()
+{
+}
+
 QVariant MprisMetaData::trackId() const
 {
     if (priv->m_metaData.contains(MetaFieldTrackId)) {

--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -329,6 +329,7 @@ namespace {
 
 MprisMetaDataPrivate::MprisMetaDataPrivate(MprisMetaData *metaData)
     : QObject(metaData)
+    , q_ptr(metaData)
 {
     m_changedDelay.setInterval(50);
     m_changedDelay.setSingleShot(true);
@@ -339,11 +340,6 @@ MprisMetaDataPrivate::MprisMetaDataPrivate(MprisMetaData *metaData)
 }
 
 MprisMetaDataPrivate::~MprisMetaDataPrivate() {}
-
-MprisMetaData *MprisMetaDataPrivate::parent() const
-{
-    return static_cast<MprisMetaData *>(QObject::parent());
-}
 
 void MprisMetaDataPrivate::fillFromPropertyChange()
 {
@@ -361,7 +357,7 @@ void MprisMetaDataPrivate::fillFrom()
     }
 
     for (auto p : m_changedProperties) {
-        parent()->setProperty(p, m_fillFromObject->property(p));
+        q_ptr->setProperty(p, m_fillFromObject->property(p));
     }
 
     m_changedProperties.clear();
@@ -414,7 +410,7 @@ void MprisMetaDataPrivate::setMetaData(const QVariantMap &metaData)
 {
     if (metaData != m_metaData) {
         m_metaData = metaData;
-        Q_EMIT parent()->metaDataChanged();
+        Q_EMIT q_ptr->metaDataChanged();
     }
 }
 

--- a/src/mprismetadata.h
+++ b/src/mprismetadata.h
@@ -33,9 +33,7 @@ class MprisMetaDataPrivate;
 class AMBER_MPRIS_EXPORT MprisMetaData : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(QVariant trackId READ trackId WRITE setTrackId NOTIFY metaDataChanged)
-
     Q_PROPERTY(QVariant duration READ duration WRITE setDuration NOTIFY metaDataChanged)
     Q_PROPERTY(QVariant artUrl READ artUrl WRITE setArtUrl NOTIFY metaDataChanged)
     Q_PROPERTY(QVariant albumTitle READ albumTitle WRITE setAlbumTitle NOTIFY metaDataChanged)

--- a/src/mprismetadata.h
+++ b/src/mprismetadata.h
@@ -30,6 +30,10 @@
 namespace Amber {
 class MprisMetaDataPrivate;
 
+// TODO: this should probably be split into read-only api on the controller side and
+// writable api on the media app side. Would be a slight API break, at least for naming.
+// also the change delay probably makes sense mostly on the media app side.
+
 class AMBER_MPRIS_EXPORT MprisMetaData : public QObject
 {
     Q_OBJECT
@@ -63,68 +67,69 @@ class AMBER_MPRIS_EXPORT MprisMetaData : public QObject
 public:
     MprisMetaData(QObject *parent = 0);
     MprisMetaData();
+    virtual ~MprisMetaData();
 
-    QVariant trackId() const;
-    void setTrackId(const QVariant &trackId);
+    virtual QVariant trackId() const;
+    virtual void setTrackId(const QVariant &trackId);
 
-    QVariant duration() const;
-    void setDuration(const QVariant &duration);
-    QVariant artUrl() const;
-    void setArtUrl(const QVariant &url);
-    QVariant albumTitle() const;
-    void setAlbumTitle(const QVariant &title);
-    QVariant albumArtist() const;
-    void setAlbumArtist(const QVariant &artist);
-    QVariant contributingArtist() const;
-    void setContributingArtist(const QVariant &artist);
-    QVariant lyrics() const;
-    void setLyrics(const QVariant &lyrics);
+    virtual QVariant duration() const;
+    virtual void setDuration(const QVariant &duration);
+    virtual QVariant artUrl() const;
+    virtual void setArtUrl(const QVariant &url);
+    virtual QVariant albumTitle() const;
+    virtual void setAlbumTitle(const QVariant &title);
+    virtual QVariant albumArtist() const;
+    virtual void setAlbumArtist(const QVariant &artist);
+    virtual QVariant contributingArtist() const;
+    virtual void setContributingArtist(const QVariant &artist);
+    virtual QVariant lyrics() const;
+    virtual void setLyrics(const QVariant &lyrics);
 
-    QVariant comment() const;
-    void setComment(const QVariant &comment);
-    QVariant composer() const;
-    void setComposer(const QVariant &composer);
-    QVariant year() const;
-    void setYear(const QVariant &year);
-    QVariant date() const;
-    void setDate(const QVariant &date);
-    QVariant discNumber() const;
-    void setDiscNumber(const QVariant &disc);
+    virtual QVariant comment() const;
+    virtual void setComment(const QVariant &comment);
+    virtual QVariant composer() const;
+    virtual void setComposer(const QVariant &composer);
+    virtual QVariant year() const;
+    virtual void setYear(const QVariant &year);
+    virtual QVariant date() const;
+    virtual void setDate(const QVariant &date);
+    virtual QVariant discNumber() const;
+    virtual void setDiscNumber(const QVariant &disc);
 
-    QVariant genre() const;
-    void setGenre(const QVariant &genre);
+    virtual QVariant genre() const;
+    virtual void setGenre(const QVariant &genre);
 
-    QVariant writer() const;
-    void setWriter(const QVariant &writer);
+    virtual QVariant writer() const;
+    virtual void setWriter(const QVariant &writer);
 
-    QVariant title() const;
-    void setTitle(const QVariant &title);
-    QVariant trackNumber() const;
-    void setTrackNumber(const QVariant &track);
+    virtual QVariant title() const;
+    virtual void setTitle(const QVariant &title);
+    virtual QVariant trackNumber() const;
+    virtual void setTrackNumber(const QVariant &track);
 
-    QVariant userRating() const;
-    void setUserRating(const QVariant &rating);
+    virtual QVariant userRating() const;
+    virtual void setUserRating(const QVariant &rating);
 
-    QVariant audioBpm() const;
-    void setAudioBpm(const QVariant &bpm);
-    QVariant autoRating() const;
-    void setAutoRating(const QVariant &rating);
-    QVariant firstUsed() const;
-    void setFirstUsed(const QVariant &used);
-    QVariant lastUsed() const;
-    void setLastUsed(const QVariant &used);
-    QVariant url() const;
-    void setUrl(const QVariant &url);
-    QVariant useCount() const;
-    void setUseCount(const QVariant &count);
+    virtual QVariant audioBpm() const;
+    virtual void setAudioBpm(const QVariant &bpm);
+    virtual QVariant autoRating() const;
+    virtual void setAutoRating(const QVariant &rating);
+    virtual QVariant firstUsed() const;
+    virtual void setFirstUsed(const QVariant &used);
+    virtual QVariant lastUsed() const;
+    virtual void setLastUsed(const QVariant &used);
+    virtual QVariant url() const;
+    virtual void setUrl(const QVariant &url);
+    virtual QVariant useCount() const;
+    virtual void setUseCount(const QVariant &count);
 
-    QVariantMap extraFields() const;
-    QVariant extraField(const QString &key) const;
-    void setExtraFields(const QVariantMap &fields);
-    void setExtraField(const QString &key, const QVariant &value);
+    virtual QVariantMap extraFields() const;
+    virtual QVariant extraField(const QString &key) const;
+    virtual void setExtraFields(const QVariantMap &fields);
+    virtual void setExtraField(const QString &key, const QVariant &value);
 
-    QVariant fillFrom() const;
-    void setFillFrom(const QVariant &fillFrom);
+    virtual QVariant fillFrom() const;
+    virtual void setFillFrom(const QVariant &fillFrom);
 
 Q_SIGNALS:
     void metaDataChanged();

--- a/src/mprismetadata_p.h
+++ b/src/mprismetadata_p.h
@@ -40,13 +40,13 @@ public:
     QVariantMap typedMetaData() const;
     void setMetaData(const QString &key, const QVariant &value);
     void setMetaData(const QVariantMap &metaData);
-    MprisMetaData *parent() const;
 
 public Q_SLOTS:
     void fillFromPropertyChange();
     void fillFrom();
 
 public:
+    MprisMetaData *q_ptr;
     QVariantMap m_metaData;
     QTimer m_changedDelay;
     QTimer m_fillFromDelay;

--- a/src/mprismetadataproxy.cpp
+++ b/src/mprismetadataproxy.cpp
@@ -1,0 +1,362 @@
+#include "mprismetadataproxy.h"
+
+#include <QDebug>
+
+MprisMetaDataProxy::MprisMetaDataProxy(QObject *parent)
+    : Amber::MprisMetaData(parent)
+{
+}
+
+MprisMetaDataProxy::~MprisMetaDataProxy()
+{
+}
+
+QVariant MprisMetaDataProxy::trackId() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->trackId();
+}
+
+void MprisMetaDataProxy::setTrackId(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::duration() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->duration();
+}
+
+void MprisMetaDataProxy::setDuration(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::artUrl() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->artUrl();
+}
+
+void MprisMetaDataProxy::setArtUrl(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::albumTitle() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->albumTitle();
+}
+
+void MprisMetaDataProxy::setAlbumTitle(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::albumArtist() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->albumArtist();
+}
+
+void MprisMetaDataProxy::setAlbumArtist(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::contributingArtist() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->contributingArtist();
+}
+
+void MprisMetaDataProxy::setContributingArtist(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::lyrics() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->lyrics();
+}
+
+void MprisMetaDataProxy::setLyrics(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::comment() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->comment();
+}
+
+void MprisMetaDataProxy::setComment(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::composer() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->composer();
+}
+
+void MprisMetaDataProxy::setComposer(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::year() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->year();
+}
+
+void MprisMetaDataProxy::setYear(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::date() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->date();
+}
+
+void MprisMetaDataProxy::setDate(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::discNumber() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->discNumber();
+}
+
+void MprisMetaDataProxy::setDiscNumber(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::genre() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->genre();
+}
+
+void MprisMetaDataProxy::setGenre(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::writer() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->writer();
+}
+
+void MprisMetaDataProxy::setWriter(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::title() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->title();
+}
+
+void MprisMetaDataProxy::setTitle(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::trackNumber() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->trackNumber();
+}
+
+void MprisMetaDataProxy::setTrackNumber(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::userRating() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->userRating();
+}
+
+void MprisMetaDataProxy::setUserRating(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::audioBpm() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->audioBpm();
+}
+
+void MprisMetaDataProxy::setAudioBpm(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::autoRating() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->autoRating();
+}
+
+void MprisMetaDataProxy::setAutoRating(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::firstUsed() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->firstUsed();
+}
+
+void MprisMetaDataProxy::setFirstUsed(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::lastUsed() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->lastUsed();
+}
+
+void MprisMetaDataProxy::setLastUsed(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::url() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->url();
+}
+
+void MprisMetaDataProxy::setUrl(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::useCount() const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->useCount();
+}
+
+void MprisMetaDataProxy::setUseCount(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariantMap MprisMetaDataProxy::extraFields() const
+{
+    if (!m_target) {
+        return QVariantMap();
+    }
+    return m_target->extraFields();
+}
+
+QVariant MprisMetaDataProxy::extraField(const QString &key) const
+{
+    if (!m_target) {
+        return QVariant();
+    }
+    return m_target->extraField(key);
+}
+
+void MprisMetaDataProxy::setExtraFields(const QVariantMap &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+void MprisMetaDataProxy::setExtraField(const QString &, const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+QVariant MprisMetaDataProxy::fillFrom() const
+{
+    return QVariant();
+}
+
+void MprisMetaDataProxy::setFillFrom(const QVariant &)
+{
+    qWarning() << "Invalid call to" << Q_FUNC_INFO;
+}
+
+void MprisMetaDataProxy::setTarget(Amber::MprisMetaData *target)
+{
+    if (target == m_target.data()) {
+        return;
+    }
+
+    m_target = target;
+    if (m_target.data()) {
+        connect(m_target.data(), &Amber::MprisMetaData::metaDataChanged,
+                this, &Amber::MprisMetaData::metaDataChanged);
+    }
+
+    metaDataChanged();
+}

--- a/src/mprismetadataproxy.h
+++ b/src/mprismetadataproxy.h
@@ -1,0 +1,79 @@
+#include "mprismetadata.h"
+
+#include <QPointer>
+
+// proxy class for forwarding property access to another instance
+class MprisMetaDataProxy : public Amber::MprisMetaData
+{
+public:
+    MprisMetaDataProxy(QObject *parent = nullptr);
+    virtual ~MprisMetaDataProxy();
+
+    virtual QVariant trackId() const;
+    virtual void setTrackId(const QVariant &trackId);
+
+    virtual QVariant duration() const;
+    virtual void setDuration(const QVariant &duration);
+    virtual QVariant artUrl() const;
+    virtual void setArtUrl(const QVariant &url);
+    virtual QVariant albumTitle() const;
+    virtual void setAlbumTitle(const QVariant &title);
+    virtual QVariant albumArtist() const;
+    virtual void setAlbumArtist(const QVariant &artist);
+    virtual QVariant contributingArtist() const;
+    virtual void setContributingArtist(const QVariant &artist);
+    virtual QVariant lyrics() const;
+    virtual void setLyrics(const QVariant &lyrics);
+
+    virtual QVariant comment() const;
+    virtual void setComment(const QVariant &comment);
+    virtual QVariant composer() const;
+    virtual void setComposer(const QVariant &composer);
+    virtual QVariant year() const;
+    virtual void setYear(const QVariant &year);
+    virtual QVariant date() const;
+    virtual void setDate(const QVariant &date);
+    virtual QVariant discNumber() const;
+    virtual void setDiscNumber(const QVariant &disc);
+
+    virtual QVariant genre() const;
+    virtual void setGenre(const QVariant &genre);
+
+    virtual QVariant writer() const;
+    virtual void setWriter(const QVariant &writer);
+
+    virtual QVariant title() const;
+    virtual void setTitle(const QVariant &title);
+    virtual QVariant trackNumber() const;
+    virtual void setTrackNumber(const QVariant &track);
+
+    virtual QVariant userRating() const;
+    virtual void setUserRating(const QVariant &rating);
+
+    virtual QVariant audioBpm() const;
+    virtual void setAudioBpm(const QVariant &bpm);
+    virtual QVariant autoRating() const;
+    virtual void setAutoRating(const QVariant &rating);
+    virtual QVariant firstUsed() const;
+    virtual void setFirstUsed(const QVariant &used);
+    virtual QVariant lastUsed() const;
+    virtual void setLastUsed(const QVariant &used);
+    virtual QVariant url() const;
+    virtual void setUrl(const QVariant &url);
+    virtual QVariant useCount() const;
+    virtual void setUseCount(const QVariant &count);
+
+    virtual QVariantMap extraFields() const;
+    virtual QVariant extraField(const QString &key) const;
+    virtual void setExtraFields(const QVariantMap &fields);
+    virtual void setExtraField(const QString &key, const QVariant &value);
+
+    virtual QVariant fillFrom() const;
+    virtual void setFillFrom(const QVariant &fillFrom);
+
+    // set metadata instance to track
+    void setTarget(Amber::MprisMetaData *target);
+
+private:
+    QPointer<Amber::MprisMetaData> m_target;
+};

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -39,6 +39,7 @@ namespace {
 
 MprisPlayerPrivate::MprisPlayerPrivate(MprisPlayer *parent)
     : QObject(parent)
+    , q_ptr(parent)
     , m_connection(nullptr)
     , m_serviceAdaptor(this)
     , m_playerAdaptor(this)
@@ -82,24 +83,19 @@ MprisPlayerPrivate::~MprisPlayerPrivate()
     }
 }
 
-MprisPlayer *MprisPlayerPrivate::parent() const
-{
-    return static_cast<MprisPlayer *>(QObject::parent());
-}
-
 void MprisPlayerPrivate::quit()
 {
-    Q_EMIT parent()->quitRequested();
+    Q_EMIT q_ptr->quitRequested();
 }
 
 void MprisPlayerPrivate::raise()
 {
-    Q_EMIT parent()->raiseRequested();
+    Q_EMIT q_ptr->raiseRequested();
 }
 
 qlonglong MprisPlayerPrivate::position() const
 {
-    return static_cast<MprisPlayer *>(parent())->position() * 1000;
+    return q_ptr->position() * 1000;
 }
 
 void MprisPlayerPrivate::setLoopStatus(const QString &value)
@@ -118,7 +114,7 @@ void MprisPlayerPrivate::setLoopStatus(const QString &value)
     }
 
     if (ok) {
-        Q_EMIT parent()->loopStatusRequested(enumVal);
+        Q_EMIT q_ptr->loopStatusRequested(enumVal);
     } else {
         sendErrorReply(QDBusError::InvalidArgs, QStringLiteral("Invalid loop status"));
     }
@@ -126,7 +122,7 @@ void MprisPlayerPrivate::setLoopStatus(const QString &value)
 
 QString MprisPlayerPrivate::loopStatus() const
 {
-    switch (parent()->loopStatus()) {
+    switch (q_ptr->loopStatus()) {
     case Mpris::LoopNone:
         return QLatin1String("None");
     case Mpris::LoopTrack:
@@ -140,134 +136,134 @@ QString MprisPlayerPrivate::loopStatus() const
 
 QString MprisPlayerPrivate::playbackStatus() const
 {
-    const char *strVal = QMetaEnum::fromType<Mpris::PlaybackStatus>().valueToKey(static_cast<int>(parent()->playbackStatus()));
+    const char *strVal = QMetaEnum::fromType<Mpris::PlaybackStatus>().valueToKey(static_cast<int>(q_ptr->playbackStatus()));
     return QString::fromLatin1(strVal);
 }
 
 void MprisPlayerPrivate::setRate(double rate)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (rate < parent()->minimumRate() || rate > parent()->maximumRate()) {
+    } else if (rate < q_ptr->minimumRate() || rate > q_ptr->maximumRate()) {
         sendErrorReply(QDBusError::InvalidArgs, QStringLiteral("Rate not in the allowed range"));
     } else {
-        Q_EMIT parent()->rateRequested(rate);
+        Q_EMIT q_ptr->rateRequested(rate);
     }
 }
 
 void MprisPlayerPrivate::setShuffle(bool shuffle)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
     } else {
-        Q_EMIT parent()->shuffleRequested(shuffle);
+        Q_EMIT q_ptr->shuffleRequested(shuffle);
     }
 }
 
 void MprisPlayerPrivate::setVolume(double volume)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
     } else {
-        Q_EMIT parent()->volumeRequested(volume);
+        Q_EMIT q_ptr->volumeRequested(volume);
     }
 }
 
 void MprisPlayerPrivate::Next()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canGoNext()) {
+    } else if (!q_ptr->canGoNext()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->nextRequested();
+        Q_EMIT q_ptr->nextRequested();
     }
 }
 
 void MprisPlayerPrivate::OpenUri(const QString &Uri)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
     } else {
-        Q_EMIT parent()->openUriRequested(QUrl::fromUserInput(Uri));
+        Q_EMIT q_ptr->openUriRequested(QUrl::fromUserInput(Uri));
     }
 }
 
 void MprisPlayerPrivate::Pause()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canPause()) {
+    } else if (!q_ptr->canPause()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->pauseRequested();
+        Q_EMIT q_ptr->pauseRequested();
     }
 }
 
 void MprisPlayerPrivate::Play()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canPlay()) {
+    } else if (!q_ptr->canPlay()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->playRequested();
+        Q_EMIT q_ptr->playRequested();
     }
 }
 
 void MprisPlayerPrivate::PlayPause()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canPlay() && !parent()->canPause()) {
+    } else if (!q_ptr->canPlay() && !q_ptr->canPause()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->playPauseRequested();
+        Q_EMIT q_ptr->playPauseRequested();
     }
 }
 
 void MprisPlayerPrivate::Previous()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canGoPrevious()) {
+    } else if (!q_ptr->canGoPrevious()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->previousRequested();
+        Q_EMIT q_ptr->previousRequested();
     }
 }
 
 void MprisPlayerPrivate::Seek(qlonglong Offset)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canSeek()) {
+    } else if (!q_ptr->canSeek()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        Q_EMIT parent()->seekRequested(Offset / 1000);
+        Q_EMIT q_ptr->seekRequested(Offset / 1000);
     }
 }
 
 void MprisPlayerPrivate::SetPosition(const QDBusObjectPath &TrackId, qlonglong position)
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
-    } else if (!parent()->canSeek()) {
+    } else if (!q_ptr->canSeek()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
         QString tid = TrackId.path();
         if (tid.startsWith(TrackPrefix))
             tid = tid.mid(TrackPrefix.size());
-        Q_EMIT parent()->setPositionRequested(tid, position / 1000);
+        Q_EMIT q_ptr->setPositionRequested(tid, position / 1000);
     }
 }
 
 void MprisPlayerPrivate::Stop()
 {
-    if (!parent()->canControl()) {
+    if (!q_ptr->canControl()) {
         sendErrorReply(QDBusError::NotSupported, QStringLiteral("The operation is not supported"));
     } else {
-        Q_EMIT parent()->stopRequested();
+        Q_EMIT q_ptr->stopRequested();
     }
 }
 

--- a/src/mprisplayer_p.h
+++ b/src/mprisplayer_p.h
@@ -37,11 +37,10 @@ public:
     MprisPlayerPrivate(MprisPlayer *parent);
     ~MprisPlayerPrivate();
 
-    MprisPlayer *parent() const;
-
     void quit();
     void raise();
 
+    MprisPlayer *q_ptr;
     QDBusConnection *m_connection;
     MprisServiceAdaptor m_serviceAdaptor;
     MprisPlayerAdaptor m_playerAdaptor;

--- a/src/mprisplayeradaptor.cpp
+++ b/src/mprisplayeradaptor.cpp
@@ -39,180 +39,160 @@ using namespace Amber;
 
 MprisPlayerAdaptor::MprisPlayerAdaptor(MprisPlayerPrivate *parent)
     : QDBusAbstractAdaptor(parent)
+    , m_playerPrivate(parent)
 {
-    // constructor
     setAutoRelaySignals(true);
 }
 
 MprisPlayerAdaptor::~MprisPlayerAdaptor()
 {
-    // destructor
-}
-
-MprisPlayerPrivate *MprisPlayerAdaptor::parent() const {
-    { return static_cast<MprisPlayerPrivate *>(QObject::parent()); }
 }
 
 bool MprisPlayerAdaptor::canControl() const
 {
-    // get the value of property CanControl
-    return static_cast<MprisPlayer *>(parent()->parent())->canControl();
+    return m_playerPrivate->q_ptr->canControl();
 }
 
 bool MprisPlayerAdaptor::canGoNext() const
 {
-    // get the value of property CanGoNext
-    return static_cast<MprisPlayer *>(parent()->parent())->canGoNext();
+    return m_playerPrivate->q_ptr->canGoNext();
 }
 
 bool MprisPlayerAdaptor::canGoPrevious() const
 {
-    // get the value of property CanGoPrevious
-    return static_cast<MprisPlayer *>(parent()->parent())->canGoPrevious();
+    return m_playerPrivate->q_ptr->canGoPrevious();
 }
 
 bool MprisPlayerAdaptor::canPause() const
 {
-    // get the value of property CanPause
-    return static_cast<MprisPlayer *>(parent()->parent())->canPause();
+    return m_playerPrivate->q_ptr->canPause();
 }
 
 bool MprisPlayerAdaptor::canPlay() const
 {
-    // get the value of property CanPlay
-    return static_cast<MprisPlayer *>(parent()->parent())->canPlay();
+    return m_playerPrivate->q_ptr->canPlay();
 }
 
 bool MprisPlayerAdaptor::canSeek() const
 {
-    // get the value of property CanSeek
-    return static_cast<MprisPlayer *>(parent()->parent())->canSeek();
+    return m_playerPrivate->q_ptr->canSeek();
 }
 
 QString MprisPlayerAdaptor::loopStatus() const
 {
-    // get the value of property LoopStatus
-    return parent()->loopStatus();
+    return m_playerPrivate->loopStatus();
 }
 
 void MprisPlayerAdaptor::setLoopStatus(const QString &value)
 {
-    // set the value of property LoopStatus
-    parent()->setLoopStatus(value);
+    m_playerPrivate->setLoopStatus(value);
 }
 
 double MprisPlayerAdaptor::maximumRate() const
 {
-    // get the value of property MaximumRate
-    return static_cast<MprisPlayer *>(parent()->parent())->maximumRate();
+    return m_playerPrivate->q_ptr->maximumRate();
 }
 
 QVariantMap MprisPlayerAdaptor::metadata() const
 {
-    return parent()->metaData();
+    return m_playerPrivate->metaData();
 }
 
 double MprisPlayerAdaptor::minimumRate() const
 {
-    // get the value of property MinimumRate
-    return qvariant_cast< double >(parent()->property("MinimumRate"));
+    return m_playerPrivate->q_ptr->minimumRate();
 }
 
 QString MprisPlayerAdaptor::playbackStatus() const
 {
-    // get the value of property PlaybackStatus
-    return parent()->playbackStatus();
+    return m_playerPrivate->playbackStatus();
 }
 
 qlonglong MprisPlayerAdaptor::position() const
 {
-    // get the value of property Position
-    return parent()->position();
+    return m_playerPrivate->position();
 }
 
 double MprisPlayerAdaptor::rate() const
 {
-    // get the value of property Rate
-    return static_cast<MprisPlayer *>(parent()->parent())->rate();
+    return m_playerPrivate->q_ptr->rate();
 }
 
 void MprisPlayerAdaptor::setRate(double value)
 {
-    parent()->setRate(value);
+    m_playerPrivate->setRate(value);
 }
 
 bool MprisPlayerAdaptor::shuffle() const
 {
-    // get the value of property Shuffle
-    return static_cast<MprisPlayer *>(parent()->parent())->shuffle();
+    return m_playerPrivate->q_ptr->shuffle();
 }
 
 void MprisPlayerAdaptor::setShuffle(bool value)
 {
-    parent()->setShuffle(value);
+    m_playerPrivate->setShuffle(value);
 }
 
 double MprisPlayerAdaptor::volume() const
 {
-    // get the value of property Volume
-    return static_cast<MprisPlayer *>(parent()->parent())->volume();
+    return m_playerPrivate->q_ptr->volume();
 }
 
 void MprisPlayerAdaptor::setVolume(double value)
 {
-    parent()->setVolume(value);
+    m_playerPrivate->setVolume(value);
 }
 
 void MprisPlayerAdaptor::Next()
 {
     // handle method call org.mpris.MediaPlayer2.Player.Next
-    parent()->Next();
+    m_playerPrivate->Next();
 }
 
 void MprisPlayerAdaptor::OpenUri(const QString &Uri)
 {
-    parent()->OpenUri(Uri);
+    m_playerPrivate->OpenUri(Uri);
 }
 
 void MprisPlayerAdaptor::Pause()
 {
     // handle method call org.mpris.MediaPlayer2.Player.Pause
-    parent()->Pause();
+    m_playerPrivate->Pause();
 }
 
 void MprisPlayerAdaptor::Play()
 {
     // handle method call org.mpris.MediaPlayer2.Player.Play
-    parent()->Play();
+    m_playerPrivate->Play();
 }
 
 void MprisPlayerAdaptor::PlayPause()
 {
     // handle method call org.mpris.MediaPlayer2.Player.PlayPause
-    parent()->PlayPause();
+    m_playerPrivate->PlayPause();
 }
 
 void MprisPlayerAdaptor::Previous()
 {
     // handle method call org.mpris.MediaPlayer2.Player.Previous
-    parent()->Previous();
+    m_playerPrivate->Previous();
 }
 
 void MprisPlayerAdaptor::Seek(qlonglong Offset)
 {
     // handle method call org.mpris.MediaPlayer2.Player.Seek
-    parent()->Seek(Offset);
+    m_playerPrivate->Seek(Offset);
 }
 
 void MprisPlayerAdaptor::SetPosition(const QDBusObjectPath &TrackId, qlonglong Position)
 {
     // handle method call org.mpris.MediaPlayer2.Player.SetPosition
-    parent()->SetPosition(TrackId, Position);
+    m_playerPrivate->SetPosition(TrackId, Position);
 }
 
 void MprisPlayerAdaptor::Stop()
 {
-    // handle method call org.mpris.MediaPlayer2.Player.priv->stop
-    parent()->Stop();
+    // handle method call org.mpris.MediaPlayer2.Player.Stop
+    m_playerPrivate->Stop();
 }
 

--- a/src/mprisplayeradaptor_p.h
+++ b/src/mprisplayeradaptor_p.h
@@ -122,8 +122,6 @@ public:
     MprisPlayerAdaptor(MprisPlayerPrivate *parent);
     virtual ~MprisPlayerAdaptor();
 
-    MprisPlayerPrivate *parent() const;
-
 public: // PROPERTIES
     Q_PROPERTY(bool CanControl READ canControl)
     bool canControl() const;
@@ -186,6 +184,9 @@ public Q_SLOTS: // METHODS
     void Stop();
 Q_SIGNALS: // SIGNALS
     void Seeked(qlonglong Position);
+
+private:
+    MprisPlayerPrivate *m_playerPrivate;
 };
 }
 

--- a/src/mprisserviceadaptor.cpp
+++ b/src/mprisserviceadaptor.cpp
@@ -41,90 +41,74 @@ using namespace Amber;
 
 MprisServiceAdaptor::MprisServiceAdaptor(MprisPlayerPrivate *parent)
     : QDBusAbstractAdaptor(parent)
+    , m_playerPrivate(parent)
 {
-    // constructor
     setAutoRelaySignals(true);
 }
 
 MprisServiceAdaptor::~MprisServiceAdaptor()
 {
-    // destructor
-}
-
-MprisPlayerPrivate *MprisServiceAdaptor::parent() const
-{
-    return static_cast<MprisPlayerPrivate *>(QObject::parent());
 }
 
 bool MprisServiceAdaptor::canQuit() const
 {
-    // get the value of property CanQuit
-    return parent()->m_canQuit;
+    return m_playerPrivate->m_canQuit;
 }
 
 bool MprisServiceAdaptor::canRaise() const
 {
-    // get the value of property CanRaise
-    return parent()->m_canRaise;
+    return m_playerPrivate->m_canRaise;
 }
 
 bool MprisServiceAdaptor::canSetFullscreen() const
 {
-    // get the value of property CanSetFullscreen
-    return parent()->m_canSetFullscreen;
+    return m_playerPrivate->m_canSetFullscreen;
 }
 
 QString MprisServiceAdaptor::desktopEntry() const
 {
-    // get the value of property DesktopEntry
-    return parent()->m_desktopEntry;
+    return m_playerPrivate->m_desktopEntry;
 }
 
 bool MprisServiceAdaptor::fullscreen() const
 {
-    // get the value of property Fullscreen
-    return parent()->m_fullscreen;
+    return m_playerPrivate->m_fullscreen;
 }
 
 void MprisServiceAdaptor::setFullscreen(bool value)
 {
-    // set the value of property Fullscreen
-    parent()->setProperty("Fullscreen", QVariant::fromValue(value));
+    m_playerPrivate->setProperty("Fullscreen", QVariant::fromValue(value));
 }
 
 bool MprisServiceAdaptor::hasTrackList() const
 {
-    // get the value of property HasTrackList
-    return parent()->m_hasTrackList;
+    return m_playerPrivate->m_hasTrackList;
 }
 
 QString MprisServiceAdaptor::identity() const
 {
-    // get the value of property Identity
-    return parent()->m_identity;
+    return m_playerPrivate->m_identity;
 }
 
 QStringList MprisServiceAdaptor::supportedMimeTypes() const
 {
-    // get the value of property SupportedMimeTypes
-    return parent()->m_supportedMimeTypes;
+    return m_playerPrivate->m_supportedMimeTypes;
 }
 
 QStringList MprisServiceAdaptor::supportedUriSchemes() const
 {
-    // get the value of property SupportedUriSchemes
-    return parent()->m_supportedUriSchemes;
+    return m_playerPrivate->m_supportedUriSchemes;
 }
 
 void MprisServiceAdaptor::Quit()
 {
     // handle method call org.mpris.MediaPlayer2.Quit
-    parent()->quit();
+    m_playerPrivate->quit();
 }
 
 void MprisServiceAdaptor::Raise()
 {
     // handle method call org.mpris.MediaPlayer2.Raise
-    parent()->raise();
+    m_playerPrivate->raise();
 }
 

--- a/src/mprisserviceadaptor_p.h
+++ b/src/mprisserviceadaptor_p.h
@@ -82,8 +82,6 @@ public:
     MprisServiceAdaptor(MprisPlayerPrivate *parent);
     virtual ~MprisServiceAdaptor();
 
-    MprisPlayerPrivate *parent() const;
-
 public: // PROPERTIES
     Q_PROPERTY(bool CanQuit READ canQuit)
     bool canQuit() const;
@@ -116,7 +114,9 @@ public: // PROPERTIES
 public Q_SLOTS: // METHODS
     void Quit();
     void Raise();
-Q_SIGNALS: // SIGNALS
+
+private:
+    MprisPlayerPrivate *m_playerPrivate;
 };
 }
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -27,6 +27,7 @@ SOURCES += \
     mprisclient.cpp \
     mpriscontroller.cpp \
     mprismetadata.cpp \
+    mprismetadataproxy.cpp \
     mprisplayer.cpp \
     mprisplayeradaptor.cpp \
     mprisplayerinterface.cpp \
@@ -40,6 +41,7 @@ HEADERS += \
     mpriscontroller.h \
     mprismetadata.h \
     mprismetadata_p.h \
+    mprismetadataproxy.h \
     mprisplayeradaptor_p.h \
     mprisplayer.h \
     mprisplayer_p.h \


### PR DESCRIPTION
From the main commit:

    Since the MprisController metaData instance was changing on different
    apps to follow, qml code such as
    
    MprisController {
      metaData.onTitleChanged: console.log(metadata.title)
    }
    
    ...didn't work. The connection was created for the initial metaData
    instance, not updated later on.
    
    Fixed by a separate proxy class, keeping the returned instance of
    MprisController always the same. The result is a bit verbose at the
    moment but it's simple. On longer run we should probably better separate
    the metadata instances on media and controller apps.

In addition a bunch of cleanup commits. Most notable being the one changing parent() calls to more explicit names. Was getting confused when sometimes parent was referring to qobject of the public class, or the public class owner of a private data, or private data of some other class etc.