### PR TITLE
Fix LoopStatus errors

### DIFF
--- a/qtdbusextended/dbusextendedabstractinterface.cpp
+++ b/qtdbusextended/dbusextendedabstractinterface.cpp
@@ -29,9 +29,6 @@
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusVariant>
 
-#include <QtCore/QDebug>
-#include <QtCore/QMetaProperty>
-
 using namespace Amber::Private;
 
 Q_GLOBAL_STATIC_WITH_ARGS(QByteArray, dBusPropertiesInterface, ("org.freedesktop.DBus.Properties"))

--- a/src/mpris.cpp
+++ b/src/mpris.cpp
@@ -1,6 +1,6 @@
 /*!
  *
- * Copyright (C) 2015-2022 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,8 +17,79 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "mpris_p.h"
 #include "mpris.h"
 
 using namespace Amber;
 
 Mpris::Mpris() {}
+
+Mpris::LoopStatus MprisPrivate::stringToLoopStatus(const QString &value, bool *ok)
+{
+    Mpris::LoopStatus enumVal = Mpris::LoopNone;
+    bool found = true;
+
+    if (value == QLatin1String("None")) {
+        enumVal = Mpris::LoopNone;
+    } else if (value == QLatin1String("Track")) {
+        enumVal = Mpris::LoopTrack;
+    } else if (value == QLatin1String("Playlist")) {
+        enumVal = Mpris::LoopPlaylist;
+    } else {
+        found = false;
+    }
+
+    if (ok) {
+        *ok = found;
+    }
+
+    return enumVal;
+}
+
+QString MprisPrivate::loopStatusToString(Mpris::LoopStatus value)
+{
+    switch (value) {
+    case Mpris::LoopNone:
+        return QStringLiteral("None");
+    case Mpris::LoopTrack:
+        return QStringLiteral("Track");
+    case Mpris::LoopPlaylist:
+        return QStringLiteral("Playlist");
+    }
+    return QString();
+}
+
+Mpris::PlaybackStatus MprisPrivate::stringToPlaybackStatus(const QString &value, bool *ok)
+{
+    Mpris::PlaybackStatus enumVal = Mpris::Stopped;
+    bool found = true;
+
+    if (value == QLatin1String("Stopped")) {
+        enumVal = Mpris::Stopped;
+    } else if (value == QLatin1String("Playing")) {
+        enumVal = Mpris::Playing;
+    } else if (value == QLatin1String("Paused")) {
+        enumVal = Mpris::Paused;
+    } else {
+        found = false;
+    }
+
+    if (ok) {
+        *ok = found;
+    }
+
+    return enumVal;
+}
+
+QString MprisPrivate::playbackToString(Mpris::PlaybackStatus value)
+{
+    switch (value) {
+    case Mpris::Stopped:
+        return QStringLiteral("Stopped");
+    case Mpris::Playing:
+        return QStringLiteral("Playing");
+    case Mpris::Paused:
+        return QStringLiteral("Paused");
+    }
+    return QString();
+}

--- a/src/mpris_p.h
+++ b/src/mpris_p.h
@@ -36,6 +36,11 @@ public:
     static QString loopStatusToString(Mpris::LoopStatus value);
     static Mpris::PlaybackStatus stringToPlaybackStatus(const QString &value, bool *ok);
     static QString playbackToString(Mpris::PlaybackStatus value);
+
+    static inline Mpris::LoopStatus stringToLoopStatus(QString value)
+    { return stringToLoopStatus(value, nullptr); }
+    static inline Mpris::PlaybackStatus stringToPlaybackStatus(QString value)
+    { return stringToPlaybackStatus(value, nullptr); }
 };
 }
 

--- a/src/mpris_p.h
+++ b/src/mpris_p.h
@@ -1,0 +1,42 @@
+// -*- c++ -*-
+
+/*!
+ *
+ * Copyright (C) 2015-2023 Jolla Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+#ifndef MPRIS_P_H
+#define MPRIS_P_H
+
+#include <mpris.h>
+
+#include <QObject>
+#include <QString>
+
+namespace Amber {
+class MprisPrivate
+{
+public:
+    static Mpris::LoopStatus stringToLoopStatus(const QString &value, bool *ok);
+    static QString loopStatusToString(Mpris::LoopStatus value);
+    static Mpris::PlaybackStatus stringToPlaybackStatus(const QString &value, bool *ok);
+    static QString playbackToString(Mpris::PlaybackStatus value);
+};
+}
+
+#endif /* MPRIS_P_H */

--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2015-2022 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -59,6 +59,7 @@
 
 #include "mprisclient_p.h"
 #include "mprismetadata_p.h"
+#include "mpris_p.h"
 
 #include <QDBusConnection>
 #include <QDBusPendingReply>
@@ -505,20 +506,14 @@ bool MprisClient::canSeek() const
 
 Mpris::LoopStatus MprisClient::loopStatus() const
 {
-    bool ok;
-    int enumVal = QMetaEnum::fromType<Mpris::LoopStatus>().keyToValue(priv->m_mprisPlayerInterface.loopStatus().toUtf8(), &ok);
-
-    if (ok) {
-        return static_cast<Mpris::LoopStatus>(enumVal);
-    }
-
-    return Mpris::LoopNone;
+    const QString &value = priv->m_mprisPlayerInterface.loopStatus();
+    return MprisPrivate::LoopStatusStringToEnum(value);
 }
 
 void MprisClient::setLoopStatus(Mpris::LoopStatus loopStatus)
 {
-    const char *strVal = QMetaEnum::fromType<Mpris::LoopStatus>().valueToKey(loopStatus);
-    priv->m_mprisPlayerInterface.setLoopStatus(QString::fromLatin1(strVal));
+    const QString &strVal = MprisPrivate::loopStatusToString(loopStatus);
+    priv->m_mprisPlayerInterface.setLoopStatus(strVal);
 }
 
 double MprisClient::maximumRate() const
@@ -538,14 +533,8 @@ double MprisClient::minimumRate() const
 
 Mpris::PlaybackStatus MprisClient::playbackStatus() const
 {
-    bool ok;
-    int enumVal = QMetaEnum::fromType<Mpris::PlaybackStatus>().keyToValue(priv->m_mprisPlayerInterface.playbackStatus().toUtf8(), &ok);
-
-    if (ok) {
-        return static_cast<Mpris::PlaybackStatus>(enumVal);
-    }
-
-    return Mpris::Stopped;
+    const QString &value = priv->m_mprisPlayerInterface.playbackStatus();
+    return MprisPrivate::PlaybackStatusStringToEnum(value);
 }
 
 qlonglong MprisClient::position() const

--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -506,8 +506,7 @@ bool MprisClient::canSeek() const
 
 Mpris::LoopStatus MprisClient::loopStatus() const
 {
-    const QString &value = priv->m_mprisPlayerInterface.loopStatus();
-    return MprisPrivate::LoopStatusStringToEnum(value);
+    return priv->m_mprisPlayerInterface.internalLoopStatus();
 }
 
 void MprisClient::setLoopStatus(Mpris::LoopStatus loopStatus)
@@ -533,8 +532,7 @@ double MprisClient::minimumRate() const
 
 Mpris::PlaybackStatus MprisClient::playbackStatus() const
 {
-    const QString &value = priv->m_mprisPlayerInterface.playbackStatus();
-    return MprisPrivate::PlaybackStatusStringToEnum(value);
+    return priv->m_mprisPlayerInterface.internalPlaybackStatus();
 }
 
 qlonglong MprisClient::position() const

--- a/src/mprisclient.cpp
+++ b/src/mprisclient.cpp
@@ -660,6 +660,7 @@ void MprisClientPrivate::onCanControlChanged()
         // I could disconnect and re-connect the signals so I avoid
         // double arriving signals but this really shouldn't happen
         // ever.
+        Q_EMIT q_ptr->canControlChanged();
         Q_EMIT q_ptr->canGoNextChanged();
         Q_EMIT q_ptr->canGoPreviousChanged();
         Q_EMIT q_ptr->canPauseChanged();
@@ -668,6 +669,10 @@ void MprisClientPrivate::onCanControlChanged()
         qCWarning(lcClient) << Q_FUNC_INFO
                             << "CanControl is not supposed to change its value!";
         return;
+    } else if (q_ptr->canControl()) {
+        // Even on the initial "GetAll" we must signal if the default
+        // false value has become true
+        Q_EMIT q_ptr->canControlChanged();
     }
 
     m_canControlReceived = true;

--- a/src/mprisclient_p.h
+++ b/src/mprisclient_p.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2015-2021 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -43,6 +43,8 @@
 #include <QVariant>
 #include <QDBusConnection>
 #include <QDBusPendingReply>
+
+#include "mpris_p.h"
 
 namespace Amber {
 /*
@@ -177,8 +179,10 @@ public:
     { return qvariant_cast< bool >(internalPropGet("CanSeek", &m_canSeek)); }
 
     Q_PROPERTY(QString LoopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
+    inline Mpris::LoopStatus internalLoopStatus()
+    { return internalPropGetInternal<Mpris::LoopStatus, QString>("LoopStatus", &m_loopStatus, &MprisPrivate::stringToLoopStatus); }
     inline QString loopStatus()
-    { return qvariant_cast< QString >(internalPropGet("LoopStatus", &m_loopStatus)); }
+    { return internalPropGetExternal<QString, Mpris::LoopStatus>("LoopStatus", &m_loopStatus, &MprisPrivate::loopStatusToString); }
     inline void setLoopStatus(const QString &value)
     { internalPropSet("LoopStatus", QVariant::fromValue(value)); }
 
@@ -195,8 +199,10 @@ public:
     { return qvariant_cast< double >(internalPropGet("MinimumRate", &m_minimumRate)); }
 
     Q_PROPERTY(QString PlaybackStatus READ playbackStatus NOTIFY playbackStatusChanged)
+    inline Mpris::PlaybackStatus internalPlaybackStatus()
+    { return internalPropGetInternal<Mpris::PlaybackStatus, QString>("PlaybackStatus", &m_playbackStatus, &MprisPrivate::stringToPlaybackStatus); }
     inline QString playbackStatus()
-    { return qvariant_cast< QString >(internalPropGet("PlaybackStatus", &m_playbackStatus)); }
+    { return internalPropGetExternal<QString, Mpris::PlaybackStatus>("PlaybackStatus", &m_playbackStatus, &MprisPrivate::playbackToString); }
 
     Q_PROPERTY(qlonglong Position READ position NOTIFY positionChanged)
     inline qlonglong position()
@@ -306,11 +312,11 @@ private:
     bool m_canPause;
     bool m_canPlay;
     bool m_canSeek;
-    QString m_loopStatus;
+    Mpris::LoopStatus m_loopStatus;
     double m_maximumRate;
     QVariantMap m_metadata;
     double m_minimumRate;
-    QString m_playbackStatus;
+    Mpris::PlaybackStatus m_playbackStatus;
     qlonglong m_position;
     double m_rate;
     bool m_shuffle;

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2015-2022 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -43,6 +43,7 @@ MprisPlayerPrivate::MprisPlayerPrivate(MprisPlayer *parent)
     , m_connection(nullptr)
     , m_serviceAdaptor(this)
     , m_playerAdaptor(this)
+    , m_playerPropertiesAdaptor(this)
     , m_canQuit(false)
     , m_canRaise(false)
     , m_canSetFullscreen(false)
@@ -272,6 +273,56 @@ QVariantMap MprisPlayerPrivate::metaData() const
     return m_metaData.priv->typedMetaData();
 }
 
+bool MprisPlayerPrivate::canQuit() const
+{
+    return m_canQuit;
+}
+
+bool MprisPlayerPrivate::canRaise() const
+{
+    return m_canRaise;
+}
+
+bool MprisPlayerPrivate::canSetFullscreen() const
+{
+    return m_canSetFullscreen;
+}
+
+QString MprisPlayerPrivate::desktopEntry() const
+{
+    return m_desktopEntry;
+}
+
+bool MprisPlayerPrivate::fullscreen() const
+{
+    return m_fullscreen;
+}
+
+bool MprisPlayerPrivate::hasTrackList() const
+{
+    return m_hasTrackList;
+}
+
+QString MprisPlayerPrivate::identity() const
+{
+    return m_identity;
+}
+
+QStringList MprisPlayerPrivate::supportedMimeTypes() const
+{
+    return m_supportedMimeTypes;
+}
+
+QStringList MprisPlayerPrivate::supportedUriSchemes() const
+{
+    return m_supportedUriSchemes;
+}
+
+void MprisPlayerPrivate::setFullscreen(bool value)
+{
+    setProperty("Fullscreen", QVariant::fromValue(value));
+}
+
 void MprisPlayerPrivate::propertyChanged(const QString &iface, const QString &name, const QVariant &value)
 {
     if (!value.isValid()) {
@@ -471,7 +522,7 @@ void MprisPlayer::setLoopStatus(Mpris::LoopStatus loopStatus)
     if (loopStatus != priv->m_loopStatus) {
         priv->m_loopStatus = loopStatus;
         Q_EMIT loopStatusChanged();
-        priv->propertyChanged(PlayerInterface, QStringLiteral("LoopStatus"), priv->m_playerAdaptor.loopStatus());
+        priv->propertyChanged(PlayerInterface, QStringLiteral("LoopStatus"), priv->loopStatus());
     }
 }
 
@@ -496,7 +547,7 @@ void MprisPlayer::setPlaybackStatus(Mpris::PlaybackStatus playbackStatus)
     if (playbackStatus != priv->m_playbackStatus) {
         priv->m_playbackStatus = playbackStatus;
         Q_EMIT playbackStatusChanged();
-        priv->propertyChanged(PlayerInterface, QStringLiteral("PlaybackStatus"), priv->m_playerAdaptor.playbackStatus());
+        priv->propertyChanged(PlayerInterface, QStringLiteral("PlaybackStatus"), priv->playbackStatus());
     }
 }
 void MprisPlayer::setPosition(qlonglong position)

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -24,6 +24,7 @@
 #include "mprismetadata_p.h"
 #include "mprismetadata.h"
 #include "ambermpris_p.h"
+#include "mpris_p.h"
 
 #include <QLoggingCategory>
 
@@ -101,21 +102,13 @@ qlonglong MprisPlayerPrivate::position() const
 
 void MprisPlayerPrivate::setLoopStatus(const QString &value)
 {
-    int enumVal;
+    Mpris::LoopStatus enumVal;
     bool ok = true;
 
-    if (value == QLatin1String("None")) {
-        enumVal = Mpris::LoopNone;
-    } else if (value == QLatin1String("Track")) {
-        enumVal = Mpris::LoopTrack;
-    } else if (value == QLatin1String("Playlist")) {
-        enumVal = Mpris::LoopPlaylist;
-    } else {
-        ok = false;
-    }
+    enumVal = MprisPrivate::stringToLoopStatus(value, &ok);
 
     if (ok) {
-        Q_EMIT q_ptr->loopStatusRequested(enumVal);
+        Q_EMIT q_ptr->loopStatusRequested(static_cast<int>(enumVal));
     } else {
         sendErrorReply(QDBusError::InvalidArgs, QStringLiteral("Invalid loop status"));
     }
@@ -123,22 +116,12 @@ void MprisPlayerPrivate::setLoopStatus(const QString &value)
 
 QString MprisPlayerPrivate::loopStatus() const
 {
-    switch (q_ptr->loopStatus()) {
-    case Mpris::LoopNone:
-        return QLatin1String("None");
-    case Mpris::LoopTrack:
-        return QLatin1String("Track");
-    case Mpris::LoopPlaylist:
-        return QLatin1String("Playlist");
-    default:
-        return QString();
-    }
+    return MprisPrivate::loopStatusToString(q_ptr->loopStatus());
 }
 
 QString MprisPlayerPrivate::playbackStatus() const
 {
-    const char *strVal = QMetaEnum::fromType<Mpris::PlaybackStatus>().valueToKey(static_cast<int>(q_ptr->playbackStatus()));
-    return QString::fromLatin1(strVal);
+    return MprisPrivate::playbackToString(q_ptr->playbackStatus());
 }
 
 void MprisPlayerPrivate::setRate(double rate)

--- a/src/mprisplayer_p.h
+++ b/src/mprisplayer_p.h
@@ -1,6 +1,6 @@
 /*!
  *
- * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,7 @@
 #include "mprismetadata.h"
 #include "mprisplayeradaptor_p.h"
 #include "mprisserviceadaptor_p.h"
+#include "mprispropertiesadaptor_p.h"
 #include "mprisplayer.h"
 
 namespace Amber {
@@ -44,6 +45,7 @@ public:
     QDBusConnection *m_connection;
     MprisServiceAdaptor m_serviceAdaptor;
     MprisPlayerAdaptor m_playerAdaptor;
+    MprisPropertiesAdaptor m_playerPropertiesAdaptor;
 
     QString m_serviceName;
     bool m_canQuit;
@@ -75,17 +77,32 @@ public:
     double m_volume;
     bool m_inPositionRequested;
 
-public:
+public Q_SLOTS:
+    // Player Adaptor
     qlonglong position() const;
     void setLoopStatus(const QString &value);
     QString loopStatus() const;
-
     QString playbackStatus() const;
+    QVariantMap metaData() const;
 
     void setVolume(double volume);
     void setRate(double rate);
     void setShuffle(bool shuffle);
 
+    // Service Adaptor
+    bool canQuit() const;
+    bool canRaise() const;
+    bool canSetFullscreen() const;
+    QString desktopEntry() const;
+    bool fullscreen() const;
+    bool hasTrackList() const;
+    QString identity() const;
+    QStringList supportedMimeTypes() const;
+    QStringList supportedUriSchemes() const;
+
+    void setFullscreen(bool value);
+
+public:
     void Next();
     void OpenUri(const QString &Uri);
     void Pause();
@@ -96,7 +113,6 @@ public:
     void SetPosition(const QDBusObjectPath &TrackId, qlonglong position);
     void Stop();
 
-    QVariantMap metaData() const;
     void propertyChanged(const QString &iface, const QString &name, const QVariant &value);
 
 private Q_SLOTS:

--- a/src/mprisplayeradaptor.cpp
+++ b/src/mprisplayeradaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,101 +46,6 @@ MprisPlayerAdaptor::MprisPlayerAdaptor(MprisPlayerPrivate *parent)
 
 MprisPlayerAdaptor::~MprisPlayerAdaptor()
 {
-}
-
-bool MprisPlayerAdaptor::canControl() const
-{
-    return m_playerPrivate->q_ptr->canControl();
-}
-
-bool MprisPlayerAdaptor::canGoNext() const
-{
-    return m_playerPrivate->q_ptr->canGoNext();
-}
-
-bool MprisPlayerAdaptor::canGoPrevious() const
-{
-    return m_playerPrivate->q_ptr->canGoPrevious();
-}
-
-bool MprisPlayerAdaptor::canPause() const
-{
-    return m_playerPrivate->q_ptr->canPause();
-}
-
-bool MprisPlayerAdaptor::canPlay() const
-{
-    return m_playerPrivate->q_ptr->canPlay();
-}
-
-bool MprisPlayerAdaptor::canSeek() const
-{
-    return m_playerPrivate->q_ptr->canSeek();
-}
-
-QString MprisPlayerAdaptor::loopStatus() const
-{
-    return m_playerPrivate->loopStatus();
-}
-
-void MprisPlayerAdaptor::setLoopStatus(const QString &value)
-{
-    m_playerPrivate->setLoopStatus(value);
-}
-
-double MprisPlayerAdaptor::maximumRate() const
-{
-    return m_playerPrivate->q_ptr->maximumRate();
-}
-
-QVariantMap MprisPlayerAdaptor::metadata() const
-{
-    return m_playerPrivate->metaData();
-}
-
-double MprisPlayerAdaptor::minimumRate() const
-{
-    return m_playerPrivate->q_ptr->minimumRate();
-}
-
-QString MprisPlayerAdaptor::playbackStatus() const
-{
-    return m_playerPrivate->playbackStatus();
-}
-
-qlonglong MprisPlayerAdaptor::position() const
-{
-    return m_playerPrivate->position();
-}
-
-double MprisPlayerAdaptor::rate() const
-{
-    return m_playerPrivate->q_ptr->rate();
-}
-
-void MprisPlayerAdaptor::setRate(double value)
-{
-    m_playerPrivate->setRate(value);
-}
-
-bool MprisPlayerAdaptor::shuffle() const
-{
-    return m_playerPrivate->q_ptr->shuffle();
-}
-
-void MprisPlayerAdaptor::setShuffle(bool value)
-{
-    m_playerPrivate->setShuffle(value);
-}
-
-double MprisPlayerAdaptor::volume() const
-{
-    return m_playerPrivate->q_ptr->volume();
-}
-
-void MprisPlayerAdaptor::setVolume(double value)
-{
-    m_playerPrivate->setVolume(value);
 }
 
 void MprisPlayerAdaptor::Next()

--- a/src/mprisplayeradaptor_p.h
+++ b/src/mprisplayeradaptor_p.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (C) 2015-2021 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -122,55 +122,7 @@ public:
     MprisPlayerAdaptor(MprisPlayerPrivate *parent);
     virtual ~MprisPlayerAdaptor();
 
-public: // PROPERTIES
-    Q_PROPERTY(bool CanControl READ canControl)
-    bool canControl() const;
-
-    Q_PROPERTY(bool CanGoNext READ canGoNext)
-    bool canGoNext() const;
-
-    Q_PROPERTY(bool CanGoPrevious READ canGoPrevious)
-    bool canGoPrevious() const;
-
-    Q_PROPERTY(bool CanPause READ canPause)
-    bool canPause() const;
-
-    Q_PROPERTY(bool CanPlay READ canPlay)
-    bool canPlay() const;
-
-    Q_PROPERTY(bool CanSeek READ canSeek)
-    bool canSeek() const;
-
-    Q_PROPERTY(QString LoopStatus READ loopStatus WRITE setLoopStatus)
-    QString loopStatus() const;
-    void setLoopStatus(const QString &value);
-
-    Q_PROPERTY(double MaximumRate READ maximumRate)
-    double maximumRate() const;
-
-    Q_PROPERTY(QVariantMap Metadata READ metadata)
-    QVariantMap metadata() const;
-
-    Q_PROPERTY(double MinimumRate READ minimumRate)
-    double minimumRate() const;
-
-    Q_PROPERTY(QString PlaybackStatus READ playbackStatus)
-    QString playbackStatus() const;
-
-    Q_PROPERTY(qlonglong Position READ position)
-    qlonglong position() const;
-
-    Q_PROPERTY(double Rate READ rate WRITE setRate)
-    double rate() const;
-    void setRate(double value);
-
-    Q_PROPERTY(bool Shuffle READ shuffle WRITE setShuffle)
-    bool shuffle() const;
-    void setShuffle(bool value);
-
-    Q_PROPERTY(double Volume READ volume WRITE setVolume)
-    double volume() const;
-    void setVolume(double value);
+    // For properties see MprisPropertiesAdaptor
 
 public Q_SLOTS: // METHODS
     void Next();

--- a/src/mprisplayerinterface.cpp
+++ b/src/mprisplayerinterface.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2015-2022 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -40,10 +40,10 @@ MprisPlayerInterface::MprisPlayerInterface(const QString &service, const QString
     , m_canPause(false)
     , m_canPlay(false)
     , m_canSeek(false)
-    , m_loopStatus(QStringLiteral("LoopNone"))
+    , m_loopStatus(Mpris::LoopNone)
     , m_maximumRate(1)
     , m_minimumRate(1)
-    , m_playbackStatus(QStringLiteral("Stopped"))
+    , m_playbackStatus(Mpris::Stopped)
     , m_position(0)
     , m_rate(1)
     , m_shuffle(false)
@@ -95,10 +95,10 @@ void MprisPlayerInterface::onPropertyChanged(const QString &propertyName, const 
             Q_EMIT canSeekChanged(m_canSeek);
         }
     } else if (propertyName == QStringLiteral("LoopStatus")) {
-        QString loopStatus = value.toString();
+        Mpris::LoopStatus loopStatus = MprisPrivate::stringToLoopStatus(value.toString());
         if (m_loopStatus != loopStatus) {
             m_loopStatus = loopStatus;
-            Q_EMIT loopStatusChanged(m_loopStatus);
+            Q_EMIT loopStatusChanged(MprisPrivate::loopStatusToString(m_loopStatus));
         }
     } else if (propertyName == QStringLiteral("MaximumRate")) {
         bool maximumRate = value.toDouble();
@@ -119,10 +119,10 @@ void MprisPlayerInterface::onPropertyChanged(const QString &propertyName, const 
             Q_EMIT minimumRateChanged(m_minimumRate);
         }
     } else if (propertyName == QStringLiteral("PlaybackStatus")) {
-        QString playbackStatus = value.toString();
+        Mpris::PlaybackStatus playbackStatus = MprisPrivate::stringToPlaybackStatus(value.toString());
         if (m_playbackStatus != playbackStatus) {
             m_playbackStatus = playbackStatus;
-            Q_EMIT playbackStatusChanged(m_playbackStatus);
+            Q_EMIT playbackStatusChanged(MprisPrivate::playbackToString(m_playbackStatus));
         }
     } else if (propertyName == QStringLiteral("Position")) {
         qlonglong position = value.toLongLong();

--- a/src/mprispropertiesadaptor.cpp
+++ b/src/mprispropertiesadaptor.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2015-2023 Jolla Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "mprisplayer_p.h"
+#include "mprispropertiesadaptor_p.h"
+
+using namespace Amber;
+
+/*
+ * Implementation of adaptor class MprisPlayerAdaptor
+ */
+
+MprisPropertiesAdaptor::MprisPropertiesAdaptor(MprisPlayerPrivate *parent)
+    : QDBusAbstractAdaptor(parent)
+    , m_playerPrivate(parent)
+{
+    setAutoRelaySignals(true);
+}
+
+MprisPropertiesAdaptor::~MprisPropertiesAdaptor()
+{
+}
+
+void MprisPropertiesAdaptor::replyPropertyNotFoundError(const QString &interface_name, const QString &property_name)
+{
+    // The property was not found
+    m_playerPrivate->sendErrorReply(QDBusError::UnknownProperty,
+                                    QString::fromLatin1("Property %1%2%3 was not found in object %4")
+                                    .arg(interface_name,
+                                         QString::fromLatin1(interface_name.isEmpty() ? "" : "."),
+                                         property_name, m_playerPrivate->message().path()));
+}
+
+void MprisPropertiesAdaptor::replyPropertyReadOnlyError(const QString &interface_name, const QString &property_name)
+{
+    // The property is read only
+    m_playerPrivate->sendErrorReply(QDBusError::PropertyReadOnly,
+                                    QString::fromLatin1("Property %1.%2 is read-only")
+                                    .arg(interface_name, property_name));
+}
+
+void MprisPropertiesAdaptor::replyInternalError()
+{
+    // The property is read only
+    m_playerPrivate->sendErrorReply(QDBusError::InternalError,
+                                    QString::fromLatin1("Internal error"));
+}
+
+// Format: {DBus property name, MprisPlayer property name or MprisPlayerPrivate getter() method}
+static const QMap<QString, QString> playerGetMap
+{
+    {"CanControl", "canControl"},
+    {"CanGoNext", "canGoNext"},
+    {"CanGoPrevious", "canGoPrevious"},
+    {"CanPause", "canPause"},
+    {"CanPlay", "canPlay"},
+    {"CanSeek", "canSeek"},
+    {"LoopStatus", "loopStatus()"},
+    {"MaximumRate", "maximumRate"},
+    {"Metadata", "metaData()"},
+    {"MinimumRate", "minimumRate"},
+    {"PlaybackStatus", "playbackStatus()"},
+    {"Position", "position()"},
+    {"Rate", "rate"},
+    {"Shuffle", "shuffle"},
+    {"Volume", "volume"},
+};
+
+static const QMap<QString, QString> serviceGetMap
+{
+    {"CanQuit", "canQuit()"},
+    {"Fullscreen", "fullscreen()"},
+    {"CanSetFullscreen", "canSetFullscreen()"},
+    {"CanRaise", "canRaise()"},
+    {"HasTrackList", "hasTrackList()"},
+    {"Identity", "identity()"},
+    {"DesktopEntry", "desktopEntry()"},
+    {"SupportedUriSchemes", "supportedMimeTypes()"},
+    {"SupportedMimeTypes", "supportedUriSchemes()"},
+};
+
+QDBusVariant MprisPropertiesAdaptor::Get(const QString &interface_name, const QString &property_name)
+{
+    QMap<QString, QString> getMap;
+    QVariant result;
+
+    if (interface_name == QLatin1String("org.mpris.MediaPlayer2.Player")) {
+        getMap = playerGetMap;
+    } else if (interface_name == QLatin1String("org.mpris.MediaPlayer2")) {
+        getMap = serviceGetMap;
+    }
+
+    const QString &getter = getMap.value(property_name);
+    if (!getter.isEmpty()) {
+        result = get(getter);
+    } else {
+        replyPropertyNotFoundError(interface_name, property_name);
+    }
+
+    return QDBusVariant(result);
+}
+
+QVariant MprisPropertiesAdaptor::get(const QString &getter)
+{
+    QVariant result;
+
+    // Start by checking MprisPlayerPrivate methods
+    int pidx = m_playerPrivate->metaObject()->indexOfMethod(
+                getter.toLocal8Bit().data());
+
+    if (pidx != -1) {
+        const QMetaMethod method = m_playerPrivate->metaObject()->method(pidx);
+        Q_ASSERT(method.parameterCount() == 0);
+
+        const int returnType = method.returnType();
+        void * returnValue = QMetaType::create(returnType);
+        bool success = method.invoke(m_playerPrivate, Qt::DirectConnection,
+                                     QGenericReturnArgument(method.typeName(),
+                                                            returnValue));
+        if (success) {
+            // Conversion to QVariant will take a copy
+            result = QVariant(returnType, returnValue);
+        } else {
+            replyInternalError();
+        }
+        QMetaType::destroy(returnType, returnValue);
+    } else {
+        // Nothing in MprisPlayerPrivate so check MprisPlayer properties instead
+        pidx = m_playerPrivate->q_ptr->metaObject()->indexOfProperty(
+                    getter.toLocal8Bit().data());
+
+        if (pidx != -1) {
+            QMetaProperty mp = m_playerPrivate->q_ptr->metaObject()->property(pidx);
+            result = mp.read(m_playerPrivate->q_ptr);
+        } else {
+            replyInternalError();
+        }
+    }
+
+    return result;
+}
+
+QVariantMap MprisPropertiesAdaptor::GetAll(const QString &interface_name)
+{
+    QVariantMap result;
+    QMap<QString, QString> getMap;
+
+    if (interface_name == QLatin1String("org.mpris.MediaPlayer2.Player")) {
+        getMap = playerGetMap;
+    } else if (interface_name == QLatin1String("org.mpris.MediaPlayer2")) {
+        getMap = serviceGetMap;
+    } else {
+        replyPropertyNotFoundError(interface_name, "");
+    }
+
+    QMap<QString, QString>::const_iterator it = getMap.constBegin();
+    while (it != getMap.constEnd()) {
+        QVariant value = get(it.value());
+        result.insert(it.key(), value);
+        ++it;
+    }
+
+    return result;
+}
+
+// Format: {DBus property name, method to call in MprisPlayerPrivate}
+static const QMap<QString, QString> playerSetMap
+{
+    {"LoopStatus", "setLoopStatus(QString)"},
+    {"Rate", "setRate(double)"},
+    {"Shuffle", "setShuffle(bool)"},
+    {"Volume", "setVolume(double)"},
+};
+
+static const QMap<QString, QString> serviceSetMap
+{
+    {"Fullscreen", "setFullscreen(bool)"},
+};
+
+void MprisPropertiesAdaptor::Set(const QString &interface_name, const QString &property_name, const QDBusVariant &value)
+{
+    QMap<QString, QString> setMap;
+    QMap<QString, QString> getMap;
+
+    if (interface_name == QLatin1String("org.mpris.MediaPlayer2.Player")) {
+        setMap = playerSetMap;
+        getMap = playerGetMap;
+    } else if (interface_name == QLatin1String("org.mpris.MediaPlayer2")) {
+        setMap = serviceSetMap;
+        getMap = serviceGetMap;
+    }
+
+    const QString &setter = setMap.value(property_name);
+    if (!setter.isEmpty()) {
+        set(setter, value);
+    } else {
+        if (getMap.contains(property_name)) {
+            replyPropertyReadOnlyError(interface_name, property_name);
+        } else {
+            replyPropertyNotFoundError(interface_name, property_name);
+        }
+    }
+}
+
+void MprisPropertiesAdaptor::set(const QString &setter, const QDBusVariant &value)
+{
+    const QMetaObject *metaobject = m_playerPrivate->metaObject();
+    bool success = false;
+
+    int pidx = metaobject->indexOfMethod(
+                setter.toLocal8Bit().data());
+
+    if (pidx != -1) {
+        QMetaMethod method = metaobject->method(pidx);
+        Q_ASSERT(method.parameterCount() == 1);
+
+        // QMetaType maps to Type, as long as our methods stick to the standard types
+        if (method.parameterType(0) == static_cast<int>(value.variant().type())) {
+            success = method.invoke(m_playerPrivate, Qt::DirectConnection,
+                                    QGenericArgument(method.parameterNames()[0],
+                                                     value.variant().data()));
+        }
+    }
+
+    if (!success) {
+        replyInternalError();
+    }
+}

--- a/src/mprispropertiesadaptor_p.h
+++ b/src/mprispropertiesadaptor_p.h
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (C) 2015-2023 Jolla Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef MPRISPROPERTIESADAPTOR_P_H
+#define MPRISPROPERTIESADAPTOR_P_H
+
+#include <QtCore/QObject>
+#include <QtDBus/QtDBus>
+
+namespace Amber {
+
+class MprisPlayerPrivate;
+
+/*
+ * Adaptor class for interface org.freedesktop.DBus.Properties
+ *
+ * This is needed because the standard QDBusAbstractAdaptor
+ * Properties implementation doesn't allow errors to be
+ * returned for the org.freedesktop.DBus.Properties.Set method,
+ * but these are needed to fulfil the MPRIS spec.
+ *
+ */
+class MprisPropertiesAdaptor: public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.freedesktop.DBus.Properties")
+    // Introspection of Get, Set and GetAll happens automatically
+    // so avoid adding them twice
+    Q_CLASSINFO("D-Bus Introspection", "")
+
+public:
+    MprisPropertiesAdaptor(MprisPlayerPrivate *parent);
+    virtual ~MprisPropertiesAdaptor();
+
+public Q_SLOTS: // METHODS
+    QDBusVariant Get(const QString &interface_name, const QString &property_name);
+    void Set(const QString &interface_name, const QString &property_name, const QDBusVariant &value);
+    QVariantMap GetAll(const QString &interface_name);
+
+private:
+    void replyPropertyNotFoundError(const QString &interface_name, const QString &property_name);
+    void replyPropertyReadOnlyError(const QString &interface_name, const QString &property_name);
+    void replyInternalError();
+
+    QVariant get(const QString &getter);
+    void set(const QString &setter, const QDBusVariant &value);
+
+    MprisPlayerPrivate *m_playerPrivate;
+};
+}
+
+#endif

--- a/src/mprisserviceadaptor.cpp
+++ b/src/mprisserviceadaptor.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2015-2021 Jolla Ltd.
+ * Copyright (C) 2015-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -48,56 +48,6 @@ MprisServiceAdaptor::MprisServiceAdaptor(MprisPlayerPrivate *parent)
 
 MprisServiceAdaptor::~MprisServiceAdaptor()
 {
-}
-
-bool MprisServiceAdaptor::canQuit() const
-{
-    return m_playerPrivate->m_canQuit;
-}
-
-bool MprisServiceAdaptor::canRaise() const
-{
-    return m_playerPrivate->m_canRaise;
-}
-
-bool MprisServiceAdaptor::canSetFullscreen() const
-{
-    return m_playerPrivate->m_canSetFullscreen;
-}
-
-QString MprisServiceAdaptor::desktopEntry() const
-{
-    return m_playerPrivate->m_desktopEntry;
-}
-
-bool MprisServiceAdaptor::fullscreen() const
-{
-    return m_playerPrivate->m_fullscreen;
-}
-
-void MprisServiceAdaptor::setFullscreen(bool value)
-{
-    m_playerPrivate->setProperty("Fullscreen", QVariant::fromValue(value));
-}
-
-bool MprisServiceAdaptor::hasTrackList() const
-{
-    return m_playerPrivate->m_hasTrackList;
-}
-
-QString MprisServiceAdaptor::identity() const
-{
-    return m_playerPrivate->m_identity;
-}
-
-QStringList MprisServiceAdaptor::supportedMimeTypes() const
-{
-    return m_playerPrivate->m_supportedMimeTypes;
-}
-
-QStringList MprisServiceAdaptor::supportedUriSchemes() const
-{
-    return m_playerPrivate->m_supportedUriSchemes;
 }
 
 void MprisServiceAdaptor::Quit()

--- a/src/mprisserviceadaptor_p.h
+++ b/src/mprisserviceadaptor_p.h
@@ -1,6 +1,6 @@
 /*!
  *
- * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021-2023 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -82,34 +82,7 @@ public:
     MprisServiceAdaptor(MprisPlayerPrivate *parent);
     virtual ~MprisServiceAdaptor();
 
-public: // PROPERTIES
-    Q_PROPERTY(bool CanQuit READ canQuit)
-    bool canQuit() const;
-
-    Q_PROPERTY(bool CanRaise READ canRaise)
-    bool canRaise() const;
-
-    Q_PROPERTY(bool CanSetFullscreen READ canSetFullscreen)
-    bool canSetFullscreen() const;
-
-    Q_PROPERTY(QString DesktopEntry READ desktopEntry)
-    QString desktopEntry() const;
-
-    Q_PROPERTY(bool Fullscreen READ fullscreen WRITE setFullscreen)
-    bool fullscreen() const;
-    void setFullscreen(bool value);
-
-    Q_PROPERTY(bool HasTrackList READ hasTrackList)
-    bool hasTrackList() const;
-
-    Q_PROPERTY(QString Identity READ identity)
-    QString identity() const;
-
-    Q_PROPERTY(QStringList SupportedMimeTypes READ supportedMimeTypes)
-    QStringList supportedMimeTypes() const;
-
-    Q_PROPERTY(QStringList SupportedUriSchemes READ supportedUriSchemes)
-    QStringList supportedUriSchemes() const;
+    // For properties see MprisPropertiesAdaptor
 
 public Q_SLOTS: // METHODS
     void Quit();

--- a/src/src.pro
+++ b/src/src.pro
@@ -37,6 +37,7 @@ SOURCES += \
 
 HEADERS += \
     mpris.h \
+    mpris_p.h \
     mprisclient.h \
     mprisclient_p.h \
     mpriscontroller.h \

--- a/src/src.pro
+++ b/src/src.pro
@@ -31,6 +31,7 @@ SOURCES += \
     mprisplayer.cpp \
     mprisplayeradaptor.cpp \
     mprisplayerinterface.cpp \
+    mprispropertiesadaptor.cpp \
     mprisrootinterface.cpp \
     mprisserviceadaptor.cpp
 
@@ -47,6 +48,7 @@ HEADERS += \
     mprisplayer_p.h \
     ambermpris.h \
     ambermpris_p.h \
+    mprispropertiesadaptor_p.h \
     mprisserviceadaptor_p.h
 
 INSTALL_HEADERS = \


### PR DESCRIPTION
1. Return DBus errors for incorrect Set parameters: Fixes a SIGSEGV when incorrect parameters were passed when setting LoopStatus and PlaybackStatus via DBus. Provides a separate DBus interface for org.freedesktop.DBus.Properties rather than using the automatic interface, so that errors can be returned when these invalid values are Set.
2. Send correct LoopStatus values. Send "None", "Track" and "Playlist" instead of "LoopNone", "LoopTrack" and "LoopPlaylist" for the LoopStatus values.
3. Use enums internally for LoopStatus and playbackStatus. Rather than storing the loopStatus and playbackStatus as QStrings, this uses the enums internally to ensure valid values are always maintained.
4. Update canControl at initialisation. Ensures that canControl emits a change signal in case it switches from false (the default) to true during initialisation. Otherwise clients won't notice that it's changed.