### PR TITLE
[mpris] Ensure Metadata.duration is scaled. Contributes to JB#59942

### DIFF
--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -470,7 +470,7 @@ void MprisMetaData::setDuration(const QVariant &duration)
     if (duration.toLongLong() <= 0)
         priv->setMetaData(MetaFieldLength, QVariant());
     else
-        priv->setMetaData(MetaFieldLength, duration);
+        priv->setMetaData(MetaFieldLength, duration.toLongLong() * 1000);
 }
 
 QVariant MprisMetaData::artUrl() const


### PR DESCRIPTION
When the duration is provided to the metadata as milliseconds it must be scaled to microseconds for internal use. This change performs this scaling.