### PR TITLE
[mpris] Don't add default path prefix. Contributes to JB#59570

### DIFF
--- a/src/mprisclient.h
+++ b/src/mprisclient.h
@@ -94,7 +94,7 @@ public:
     Q_INVOKABLE bool previous();
     Q_INVOKABLE bool seek(qlonglong offset);
     Q_INVOKABLE bool setPosition(qlonglong position);
-    Q_INVOKABLE bool setPosition(const QString &aTrackId, qlonglong position);
+    Q_INVOKABLE bool setPosition(const QVariant &aTrackId, qlonglong position);
     Q_INVOKABLE bool stop();
 
     QString service() const;

--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -423,7 +423,7 @@
 
     Signals the controlled player that it should move they playback position
     to specified location in milliseconds. The trackId must be the trackId of the
-    currently playing track.
+    currently playing track and must be formatted as a valid DBus path.
 
     Returns true if the request was successfully sent, remote
     errors are not reported.
@@ -598,7 +598,7 @@ bool MprisController::setPosition(qlonglong position) const
     return priv->checkClient(Q_FUNC_INFO) && priv->m_currentClient->setPosition(position);
 }
 
-bool MprisController::setPosition(const QString &trackId, qlonglong position) const
+bool MprisController::setPosition(const QVariant &trackId, qlonglong position) const
 {
     return priv->checkClient(Q_FUNC_INFO) && priv->m_currentClient->setPosition(trackId, position);
 }

--- a/src/mpriscontroller.h
+++ b/src/mpriscontroller.h
@@ -94,7 +94,7 @@ public:
     Q_INVOKABLE bool previous() const;
     Q_INVOKABLE bool seek(qlonglong offset) const;
     Q_INVOKABLE bool setPosition(qlonglong position) const;
-    Q_INVOKABLE bool setPosition(const QString &trackId, qlonglong position) const;
+    Q_INVOKABLE bool setPosition(const QVariant &trackId, qlonglong position) const;
     Q_INVOKABLE bool stop() const;
 
     bool singleService() const;

--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -25,7 +25,8 @@
     Provides access to information about media content.
 
     All properties may be undefined if not applicable or known.
-    A default trackId will be returned if one is not defined.
+    A default trackId of \c{/org/mpris/MediaPlayer2/TrackList/NoTrack}
+    will be returned if one is not defined.
 */
 
 /*!
@@ -256,12 +257,11 @@ namespace {
 
     const QString MetaFieldInternalYear = QStringLiteral("year");
 
-    const QString TrackObjectPathPrefix = QStringLiteral("/org/mpris/MediaPlayer2/TrackList/");
+    const QString NoTrackObjectPath = QStringLiteral("/org/mpris/MediaPlayer2/TrackList/NoTrack");
 
     bool validateTrackIdAsObjectPath(const QString &trackId)
     {
-        QDBusObjectPath objectPath(trackId.startsWith('/') ? trackId : (TrackObjectPathPrefix + trackId));
-        return !objectPath.path().isEmpty();
+        return !QDBusObjectPath(trackId).path().isEmpty();
     }
 
     template<class T> QVariant ensureType(const QVariant &from)
@@ -281,18 +281,19 @@ namespace {
 
     template<> QVariant ensureType<QDBusObjectPath>(const QVariant &from)
     {
-        QString path;
+        QDBusObjectPath path;
 
-        if (from.isNull()) {
-            path = TrackObjectPathPrefix + QLatin1String("NoTrack");
-        } else {
-            path = from.toString();
-            if (!path.startsWith('/')) {
-                path = TrackObjectPathPrefix + path;
-            }
+        if (from.userType() == qMetaTypeId<QDBusObjectPath>()) {
+            path = from.value<QDBusObjectPath>();
+        } else if (from.userType() == qMetaTypeId<QString>()) {
+            path = QDBusObjectPath(from.toString());
         }
 
-        return QVariant::fromValue(QDBusObjectPath(path));
+        if (path.path().isEmpty()) {
+            path = QDBusObjectPath(NoTrackObjectPath);
+        }
+
+        return QVariant::fromValue(path);
     }
 
     QVariant convertLength(const QVariant &from) {
@@ -427,10 +428,6 @@ MprisMetaData::~MprisMetaData()
 QVariant MprisMetaData::trackId() const
 {
     if (priv->m_metaData.contains(MetaFieldTrackId)) {
-        QString trackId = priv->m_metaData[MetaFieldTrackId].toString();
-        if (trackId.startsWith(TrackObjectPathPrefix)) {
-            return trackId.mid(TrackObjectPathPrefix.size());
-        }
         return priv->m_metaData[MetaFieldTrackId];
     }
 

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -235,10 +235,7 @@ void MprisPlayerPrivate::SetPosition(const QDBusObjectPath &TrackId, qlonglong p
     } else if (!q_ptr->canSeek()) {
         sendErrorReply(QDBusError::Failed, QStringLiteral("The operation can not be performed"));
     } else {
-        QString tid = TrackId.path();
-        if (tid.startsWith(TrackPrefix))
-            tid = tid.mid(TrackPrefix.size());
-        Q_EMIT q_ptr->setPositionRequested(tid, position / 1000);
+        Q_EMIT q_ptr->setPositionRequested(TrackId.path(), position / 1000);
     }
 }
 


### PR DESCRIPTION
Rather than adding/removing the default prefix, this change leaves the prefix choice to the application, and doesn't perform any stripping.

The path still has to be formatted as a valid DBus path. If something invalid is used, it will be replaced by
"/org/mpris/MediaPlayer2/TrackList/NoTrack".