### PR TITLE
Add hasShuffle and hasLoopStatus properties

### DIFF
--- a/declarative/declarativemprisplayer.cpp
+++ b/declarative/declarativemprisplayer.cpp
@@ -139,8 +139,14 @@ using namespace Amber;
     \brief Indicates whether the player can be controlled remotely
 
     Should be set to true if the player can receive any remote control
-    commands. This should not change value during the lifetime of the
-    player.
+    commands.
+
+    This value must remain constant during the lifetime of the
+    player and the value can't be changed after the first controller
+    has connected.
+
+    In order to change the value, a new \l MprisPlayer should be
+    instantiated.
 
     Defaults to false.
 */
@@ -196,6 +202,41 @@ using namespace Amber;
     setPositionRequested signals.
 
     Defaults to false.
+*/
+
+/*!
+    \qmlproperty bool MprisPlayer::hasShuffle
+    \brief Indicates whether the player has shuffle property
+
+    Should be set to true if shuffle property of the play queue can be
+    accessed. If set to true, remote controllers can read and set shuffle
+    property.
+
+    This value must remain constant during the lifetime of the
+    player and the value can't be changed after the first controller
+    has connected.
+
+    In order to change the value, a new \l MprisPlayer should be
+    instantiated.
+
+    Defaults to true.
+*/
+
+/*!
+    \qmlproperty bool MprisPlayer::hasLoopStatus
+    \brief Indicates whether the player has loopStatus property
+
+    Should be set to true if the loop status can be accessed. If set to true,
+    remote controllers can read and set loopStatus property.
+
+    This value must remain constant during the lifetime of the
+    player and the value can't be changed after the first controller
+    has connected.
+
+    In order to change the value, a new \l MprisPlayer should be
+    instantiated.
+
+    Defaults to true.
 */
 
 /*!

--- a/src/mprisclient.h
+++ b/src/mprisclient.h
@@ -62,6 +62,8 @@ class AMBER_MPRIS_EXPORT MprisClient : public QObject
     Q_PROPERTY(bool canPause READ canPause NOTIFY canPauseChanged)
     Q_PROPERTY(bool canPlay READ canPlay NOTIFY canPlayChanged)
     Q_PROPERTY(bool canSeek READ canSeek NOTIFY canSeekChanged)
+    Q_PROPERTY(bool hasShuffle READ hasShuffle NOTIFY hasShuffleChanged)
+    Q_PROPERTY(bool hasLoopStatus READ hasLoopStatus NOTIFY hasLoopStatusChanged)
     Q_PROPERTY(Amber::Mpris::LoopStatus loopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
     Q_PROPERTY(double maximumRate READ maximumRate NOTIFY maximumRateChanged)
     Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData CONSTANT)
@@ -118,6 +120,8 @@ public:
     bool canPause() const;
     bool canPlay() const;
     bool canSeek() const;
+    bool hasShuffle() const;
+    bool hasLoopStatus() const;
 
     Mpris::LoopStatus loopStatus() const;
     void setLoopStatus(Mpris::LoopStatus loopStatus);
@@ -162,6 +166,8 @@ Q_SIGNALS:
     void canPauseChanged();
     void canPlayChanged();
     void canSeekChanged();
+    void hasShuffleChanged();
+    void hasLoopStatusChanged();
     void loopStatusChanged();
     void maximumRateChanged();
     void minimumRateChanged();

--- a/src/mprisclient_p.h
+++ b/src/mprisclient_p.h
@@ -178,6 +178,14 @@ public:
     inline bool canSeek()
     { return qvariant_cast< bool >(internalPropGet("CanSeek", &m_canSeek)); }
 
+    Q_PROPERTY(bool HasShuffle READ hasShuffle NOTIFY hasShuffleChanged)
+    inline bool hasShuffle()
+    { return m_hasShuffle; }
+
+    Q_PROPERTY(bool HasLoopStatus READ hasLoopStatus NOTIFY hasLoopStatusChanged)
+    inline bool hasLoopStatus()
+    { return m_hasLoopStatus; }
+
     Q_PROPERTY(QString LoopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
     inline Mpris::LoopStatus internalLoopStatus()
     { return internalPropGetInternal<Mpris::LoopStatus, QString>("LoopStatus", &m_loopStatus, &MprisPrivate::stringToLoopStatus); }
@@ -291,6 +299,8 @@ Q_SIGNALS: // SIGNALS
     void canPauseChanged(bool canPause);
     void canPlayChanged(bool canPlay);
     void canSeekChanged(bool canSeek);
+    void hasLoopStatusChanged(bool hasLoopStatus);
+    void hasShuffleChanged(bool hasShuffle);
     void loopStatusChanged(const QString &loopStatus);
     void maximumRateChanged(double maximumRate);
     void metadataChanged(const QVariantMap &metadata);
@@ -312,6 +322,8 @@ private:
     bool m_canPause;
     bool m_canPlay;
     bool m_canSeek;
+    bool m_hasShuffle;
+    bool m_hasLoopStatus;
     Mpris::LoopStatus m_loopStatus;
     double m_maximumRate;
     QVariantMap m_metadata;

--- a/src/mpriscontroller.cpp
+++ b/src/mpriscontroller.cpp
@@ -178,6 +178,13 @@
 
     When set to false, no control of the player is expected to work,
     only status can be read.
+
+    When set to false, all other control flags (e.g. \l canPlay,
+    \l canPause, \l canGoNext) are automatically set to false.
+
+    According to the specification, this should not change value after
+    the controller becomes valid, but this restriction is only imposed
+    on the \l MprisPlayer side.
 */
 
 /*!
@@ -223,6 +230,32 @@
 
     When set, the seek and setPosition methods  can be called to instruct the
     controlled player to move within the currently playin media.
+*/
+
+/*!
+    \qmlproperty bool MprisController::hasShuffle
+    \brief Indicates whether the shuffle status can be controlled
+
+    When set to false, attempting to set the shuffle property will have
+    no effect as the player doesn't offer the ability to set the shuffle
+    status.
+
+    According to the specification, this should not change value after
+    the controller becomes valid, but this restriction is only imposed
+    on the \l MprisPlayer side.
+*/
+
+/*!
+    \qmlproperty bool MprisController::hasLoopStatus
+    \brief Indicates whether the loop status can be controlled
+
+    When set to false, attempting to set the loopStatus property will have
+    no effect as the player doesn't offer the ability to set the loop
+    status.
+
+    According to the specification, this should not change value after
+    the controller becomes valid, but this restriction is only imposed
+    on the \l MprisPlayer side.
 */
 
 /*!
@@ -770,6 +803,16 @@ bool MprisController::canSeek() const
     return priv->m_currentClient && priv->m_currentClient->canSeek();
 }
 
+bool MprisController::hasShuffle() const
+{
+    return priv->m_currentClient && priv->m_currentClient->hasShuffle();
+}
+
+bool MprisController::hasLoopStatus() const
+{
+    return priv->m_currentClient && priv->m_currentClient->hasLoopStatus();
+}
+
 Mpris::LoopStatus MprisController::loopStatus() const
 {
     return priv->m_currentClient ? priv->m_currentClient->loopStatus() : Mpris::LoopNone;
@@ -1090,6 +1133,8 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
         disconnect(m_currentClient, &MprisClient::canPauseChanged, q_ptr, &MprisController::canPauseChanged);
         disconnect(m_currentClient, &MprisClient::canPlayChanged, q_ptr, &MprisController::canPlayChanged);
         disconnect(m_currentClient, &MprisClient::canSeekChanged, q_ptr, &MprisController::canSeekChanged);
+        disconnect(m_currentClient, &MprisClient::hasShuffleChanged, q_ptr, &MprisController::hasShuffleChanged);
+        disconnect(m_currentClient, &MprisClient::hasLoopStatusChanged, q_ptr, &MprisController::hasLoopStatusChanged);
         disconnect(m_currentClient, &MprisClient::loopStatusChanged, q_ptr, &MprisController::loopStatusChanged);
         disconnect(m_currentClient, &MprisClient::maximumRateChanged, q_ptr, &MprisController::maximumRateChanged);
         disconnect(m_currentClient, &MprisClient::minimumRateChanged, q_ptr, &MprisController::minimumRateChanged);
@@ -1120,6 +1165,8 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
     bool oldCanPause = q_ptr->canPause();
     bool oldCanPlay = q_ptr->canPlay();
     bool oldCanSeek = q_ptr->canSeek();
+    bool oldHasShuffle = q_ptr->hasShuffle();
+    bool oldHasLoopStatus = q_ptr->hasLoopStatus();
     Mpris::LoopStatus oldLoopStatus = q_ptr->loopStatus();
     double oldMaximumRate = q_ptr->maximumRate();
     double oldMinimumRate = q_ptr->minimumRate();
@@ -1177,6 +1224,12 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
     if (oldCanSeek != q_ptr->canSeek()) {
         Q_EMIT q_ptr->canSeekChanged();
     }
+    if (oldHasShuffle != q_ptr->hasShuffle()) {
+        Q_EMIT q_ptr->hasShuffleChanged();
+    }
+    if (oldHasLoopStatus != q_ptr->hasLoopStatus()) {
+        Q_EMIT q_ptr->hasLoopStatusChanged();
+    }
     if (oldLoopStatus != q_ptr->loopStatus()) {
         Q_EMIT q_ptr->loopStatusChanged();
     }
@@ -1218,6 +1271,8 @@ void MprisControllerPrivate::setCurrentClient(MprisClient *client)
         connect(m_currentClient, &MprisClient::canPauseChanged, q_ptr, &MprisController::canPauseChanged);
         connect(m_currentClient, &MprisClient::canPlayChanged, q_ptr, &MprisController::canPlayChanged);
         connect(m_currentClient, &MprisClient::canSeekChanged, q_ptr, &MprisController::canSeekChanged);
+        connect(m_currentClient, &MprisClient::hasShuffleChanged, q_ptr, &MprisController::hasShuffleChanged);
+        connect(m_currentClient, &MprisClient::hasLoopStatusChanged, q_ptr, &MprisController::hasLoopStatusChanged);
         connect(m_currentClient, &MprisClient::loopStatusChanged, q_ptr, &MprisController::loopStatusChanged);
         connect(m_currentClient, &MprisClient::maximumRateChanged, q_ptr, &MprisController::maximumRateChanged);
         connect(m_currentClient, &MprisClient::minimumRateChanged, q_ptr, &MprisController::minimumRateChanged);

--- a/src/mpriscontroller.h
+++ b/src/mpriscontroller.h
@@ -67,6 +67,8 @@ class AMBER_MPRIS_EXPORT MprisController : public QObject
     Q_PROPERTY(bool canPause READ canPause NOTIFY canPauseChanged)
     Q_PROPERTY(bool canPlay READ canPlay NOTIFY canPlayChanged)
     Q_PROPERTY(bool canSeek READ canSeek NOTIFY canSeekChanged)
+    Q_PROPERTY(bool hasShuffle READ hasShuffle NOTIFY hasShuffleChanged)
+    Q_PROPERTY(bool hasLoopStatus READ hasLoopStatus NOTIFY hasLoopStatusChanged)
     Q_PROPERTY(Amber::Mpris::LoopStatus loopStatus READ loopStatus WRITE setLoopStatus NOTIFY loopStatusChanged)
     Q_PROPERTY(double maximumRate READ maximumRate NOTIFY maximumRateChanged)
     Q_PROPERTY(Amber::MprisMetaData *metaData READ metaData CONSTANT)
@@ -127,6 +129,8 @@ public:
     bool canPause() const;
     bool canPlay() const;
     bool canSeek() const;
+    bool hasShuffle() const;
+    bool hasLoopStatus() const;
 
     Mpris::LoopStatus loopStatus() const;
     void setLoopStatus(Mpris::LoopStatus loopStatus);
@@ -172,6 +176,8 @@ Q_SIGNALS:
     void canPauseChanged();
     void canPlayChanged();
     void canSeekChanged();
+    void hasShuffleChanged();
+    void hasLoopStatusChanged();
     void loopStatusChanged();
     void maximumRateChanged();
     void minimumRateChanged();

--- a/src/mprisplayer.h
+++ b/src/mprisplayer.h
@@ -60,6 +60,8 @@ class AMBER_MPRIS_EXPORT MprisPlayer : public QObject
     Q_PROPERTY(double rate READ rate WRITE setRate NOTIFY rateChanged)
     Q_PROPERTY(bool shuffle READ shuffle WRITE setShuffle NOTIFY shuffleChanged)
     Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
+    Q_PROPERTY(bool hasShuffle READ hasShuffle WRITE setHasShuffle NOTIFY hasShuffleChanged)
+    Q_PROPERTY(bool hasLoopStatus READ hasLoopStatus WRITE setHasLoopStatus NOTIFY hasLoopStatusChanged)
 
 public:
     MprisPlayer(QObject *parent = 0);
@@ -82,6 +84,8 @@ public:
     bool canPause() const;
     bool canPlay() const;
     bool canSeek() const;
+    bool hasShuffle() const;
+    bool hasLoopStatus() const;
     Mpris::LoopStatus loopStatus() const;
     double maximumRate() const;
     MprisMetaData *metaData() const;
@@ -117,6 +121,8 @@ public:
     void setRate(double rate);
     void setShuffle(bool shuffle);
     void setVolume(double volume);
+    void setHasShuffle(bool hasShuffle);
+    void setHasLoopStatus(bool hasLoopStatus);
 
 Q_SIGNALS:
     void serviceNameChanged();
@@ -149,6 +155,8 @@ Q_SIGNALS:
     void rateChanged();
     void shuffleChanged();
     void volumeChanged();
+    void hasShuffleChanged();
+    void hasLoopStatusChanged();
 
     void positionRequested();
     void loopStatusRequested(int loopStatus);

--- a/src/mprisplayer_p.h
+++ b/src/mprisplayer_p.h
@@ -67,6 +67,8 @@ public:
     bool m_canPause;
     bool m_canPlay;
     bool m_canSeek;
+    bool m_hasShuffle;
+    bool m_hasLoopStatus;
     Mpris::LoopStatus m_loopStatus;
     double m_maximumRate;
     double m_minimumRate;

--- a/src/mprisplayerinterface.cpp
+++ b/src/mprisplayerinterface.cpp
@@ -40,6 +40,8 @@ MprisPlayerInterface::MprisPlayerInterface(const QString &service, const QString
     , m_canPause(false)
     , m_canPlay(false)
     , m_canSeek(false)
+    , m_hasShuffle(false)
+    , m_hasLoopStatus(false)
     , m_loopStatus(Mpris::LoopNone)
     , m_maximumRate(1)
     , m_minimumRate(1)
@@ -95,6 +97,10 @@ void MprisPlayerInterface::onPropertyChanged(const QString &propertyName, const 
             Q_EMIT canSeekChanged(m_canSeek);
         }
     } else if (propertyName == QStringLiteral("LoopStatus")) {
+        if (!m_hasLoopStatus) {
+            m_hasLoopStatus = true;
+            Q_EMIT hasLoopStatusChanged(true);
+        }
         Mpris::LoopStatus loopStatus = MprisPrivate::stringToLoopStatus(value.toString());
         if (m_loopStatus != loopStatus) {
             m_loopStatus = loopStatus;
@@ -137,6 +143,10 @@ void MprisPlayerInterface::onPropertyChanged(const QString &propertyName, const 
             Q_EMIT rateChanged(m_rate);
         }
     } else if (propertyName == QStringLiteral("Shuffle")) {
+        if (!m_hasShuffle) {
+            m_hasShuffle = true;
+            Q_EMIT hasShuffleChanged(true);
+        }
         bool shuffle = value.toBool();
         if (m_shuffle != shuffle) {
             m_shuffle = shuffle;

--- a/src/mprispropertiesadaptor_p.h
+++ b/src/mprispropertiesadaptor_p.h
@@ -48,6 +48,10 @@ public:
     MprisPropertiesAdaptor(MprisPlayerPrivate *parent);
     virtual ~MprisPropertiesAdaptor();
 
+    bool propertiesLocked() const;
+    void hideProperty(const QString &property, bool hidden);
+    void reset();
+
 public Q_SLOTS: // METHODS
     QDBusVariant Get(const QString &interface_name, const QString &property_name);
     void Set(const QString &interface_name, const QString &property_name, const QDBusVariant &value);
@@ -62,6 +66,8 @@ private:
     void set(const QString &setter, const QDBusVariant &value);
 
     MprisPlayerPrivate *m_playerPrivate;
+    bool m_propertiesLocked;
+    QSet<QString> m_maskedProperties;
 };
 }
 


### PR DESCRIPTION
Adds canShuffle and canLoop properties to indicate whether or not the Shuffle and LoopStatus properties are supported.

These work by exposing/hiding the DBus property, so work within the MPRIS specification.