### PR TITLE
Drop length conversion

### DIFF
--- a/src/mprismetadata.cpp
+++ b/src/mprismetadata.cpp
@@ -295,15 +295,9 @@ namespace {
         return QVariant::fromValue(QDBusObjectPath(path));
     }
 
-    QVariant convertLength(const QVariant &from) {
-        if (from.isNull())
-            return QVariant();
-        return QVariant::fromValue(qvariant_cast<qint64>(from) * 1000);
-    }
-
     const QMap<QString, QVariant (*)(const QVariant &)> converters {
         { MetaFieldTrackId, ensureType<QDBusObjectPath> },
-        { MetaFieldLength, convertLength },
+        { MetaFieldLength, ensureType<qint64> },
         { MetaFieldArtUrl, ensureType<QString> },
         { MetaFieldAlbum, ensureType<QString> },
         { MetaFieldAlbumArtist, ensureType<QStringList> },


### PR DESCRIPTION
Since commit 9d671c040e133cf8f1212ea709adb05754564e2f duration is scaled when it's stored in the dictionary. Drop this conversion that would scale the values again.