### PR TITLE
Fix builds with Qt 6

### DIFF
--- a/src/mpriscontroller.h
+++ b/src/mpriscontroller.h
@@ -25,6 +25,7 @@
 
 #include <ambermpris.h>
 #include <Mpris>
+#include <MprisMetaData>
 
 #include <QDBusConnection>
 #include <QDBusObjectPath>
@@ -36,7 +37,6 @@
 
 namespace Amber {
 
-class MprisMetaData;
 class MprisControllerPrivate;
 
 class AMBER_MPRIS_EXPORT MprisController : public QObject

--- a/src/mprisplayer.h
+++ b/src/mprisplayer.h
@@ -22,12 +22,12 @@
 
 #include <QObject>
 #include <ambermpris.h>
-#include <mpris.h>
+#include <Mpris>
+#include <MprisMetaData>
 
 namespace Amber {
 
 class MprisPlayerPrivate;
-class MprisMetaData;
 
 class AMBER_MPRIS_EXPORT MprisPlayer : public QObject
 {

--- a/src/mprisplayeradaptor_p.h
+++ b/src/mprisplayeradaptor_p.h
@@ -24,15 +24,7 @@
 
 #include <QtCore/QObject>
 #include <QtDBus/QtDBus>
-
-QT_BEGIN_NAMESPACE
-class QByteArray;
-template<class T> class QList;
-template<class Key, class Value> class QMap;
-class QString;
-class QStringList;
-class QVariant;
-QT_END_NAMESPACE
+#include <QString>
 
 namespace Amber {
 

--- a/src/mprisserviceadaptor_p.h
+++ b/src/mprisserviceadaptor_p.h
@@ -29,15 +29,6 @@
 #include <QtDBus/QtDBus>
 
 
-QT_BEGIN_NAMESPACE
-class QByteArray;
-template<class T> class QList;
-template<class Key, class Value> class QMap;
-class QString;
-class QStringList;
-class QVariant;
-QT_END_NAMESPACE
-
 /*
  * Adaptor class for interface org.mpris.MediaPlayer2
  */


### PR DESCRIPTION
This fixes building with Qt 6 and removes all deprecation warnings as a bonus.

Main things to adapt:
-  A few places like `QVariant` and `QDBusMetaType` no longer accepted `int` but wanted `QMetaType`. That had to be ifdef'd because those versions of the methods were only introduced in Qt 6.
- Forward declarations of Qt types are forbidden in some places.
- Opaque pointers as property types need to be declared.
- `QVariant::type()` is deprecated while `QVariant::userType()` is fine to use still.