### PR TITLE
Fix segfault in MprisPlayerPrivate::emitPropertiesChanged()

### DIFF
--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -308,6 +308,9 @@ void MprisPlayerPrivate::setFullscreen(bool value)
 
 void MprisPlayerPrivate::propertyChanged(const QString &iface, const QString &name, const QVariant &value)
 {
+    if (!m_connection)
+        return;
+
     if (!value.isValid()) {
         m_changedProperties[iface].first.remove(name);
         m_changedProperties[iface].second << name;
@@ -667,6 +670,8 @@ void MprisPlayer::setServiceName(const QString &serviceName)
         delete priv->m_connection;
         priv->m_connection = nullptr;
         priv->m_playerPropertiesAdaptor.reset();
+        priv->m_changedDelay.stop();
+        priv->m_changedProperties.clear();
     }
 
     if (!serviceName.isEmpty()) {

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -321,6 +321,9 @@ void MprisPlayerPrivate::propertyChanged(const QString &iface, const QString &na
 
 void MprisPlayerPrivate::emitPropertiesChanged()
 {
+    if (!m_connection)
+        return;
+
     for (auto i = m_changedProperties.cbegin();
          i != m_changedProperties.cend();
          ++i) {


### PR DESCRIPTION
Prevent crash when handling property change timer.  Avoid null pointer dereference in case service name has been cleared (or never set). This first commit only prevents the crash but doesn't attempt to do any cleanup.

Avoid property change signals while disconnected. Don't set property change timer while there is no D-Bus connection. Clear the change timer and changed properties when disconnecting.