### PR TITLE
%make_install doesnt work with qmake6 projects

### DIFF
--- a/rpm/amber-mpris-qt6.spec
+++ b/rpm/amber-mpris-qt6.spec
@@ -40,7 +40,7 @@ export PATH=$PATH:%{_qt6_bindir}
 %make_build
 
 %install
-%make_install
+make install INSTALL_ROOT="%buildroot"
 
 %post -p /sbin/ldconfig
 


### PR DESCRIPTION
qmake6 --install requires INSTALL_ROOT to be set to buildroot, and this isnt covered by %make_install.  As per openSuse packaging guide, instead use:
make install INSTALL_ROOT="%buildroot"